### PR TITLE
<#24> feat : 인터뷰 리스트 화면 배치

### DIFF
--- a/front-end/src/app.jsx
+++ b/front-end/src/app.jsx
@@ -8,6 +8,7 @@ import {
 import Home from './pages/home.jsx';
 import Login from './pages/login.jsx';
 import InterviewList from './pages/interviewList.jsx';
+import CardNews from './pages/cardNews.jsx';
 
 import ChippoHeader from './components/header.jsx';
 
@@ -21,10 +22,11 @@ function App(){
         <Router>
             <ChippoHeader />
             <Routes>
-                <Route path = "/login" element = {<Login />} />
                 <Route path = "/" element = {<Home />} />
+                <Route path = "/login" element = {<Login />} />
+
                 <Route path = "/username" element = {<Home />} />
-                <Route path = "/:name" element = {<InterviewList />}/>
+                <Route path = "/:name" element = {<InterviewList />} />
             </Routes>
             
         </Router>   

--- a/front-end/src/app.jsx
+++ b/front-end/src/app.jsx
@@ -26,7 +26,8 @@ function App(){
                 <Route path = "/login" element = {<Login />} />
 
                 <Route path = "/username" element = {<Home />} />
-                <Route path = "/:name" element = {<InterviewList />} />
+                <Route path = "/:name" element = {<InterviewList />} /> 
+                <Route path = "/:name/:interviewId" element = {<CardNews />} />
             </Routes>
             
         </Router>   

--- a/front-end/src/components/theme/common.style.js
+++ b/front-end/src/components/theme/common.style.js
@@ -1,7 +1,5 @@
 import styled from '@emotion/styled';
 
-// import logo from './img/logo.png'
-
 const Header = styled.header`
     color : #5078E7;
     font-size : 32px;

--- a/front-end/src/pages/cardNews.jsx
+++ b/front-end/src/pages/cardNews.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function CardNews(){
+    return <div>주관식 카드뉴스입니다.</div>;
+}
+
+export default CardNews;

--- a/front-end/src/pages/interviewList.jsx
+++ b/front-end/src/pages/interviewList.jsx
@@ -1,8 +1,53 @@
-import React from 'react';
+import React, { useState }  from 'react';
+import { Center, Box, VStack } from "@chakra-ui/react"
+import { useParams, Route, Routes, Link } from "react-router-dom";
+
+import { Section } from '../components/theme/common.style.js';
+import CardNews from "./cardNews.jsx";
 
 function InterviewList(){
+    const params = useParams();
+
+    const [interviewList, setinterviewList] = useState([
+        {_id : 1, context : "해당 프로젝트를 할 때 리액트를 선택한 이유는 무엇인가?"},
+        {_id : 2, context : "spring mvc 패턴이란 ?"},
+        {_id : 3, context : "javascript의 var, const, let의 차이는 무엇입니까??"},
+        {_id : 4, context : "함수형 프로그래밍에 대해 간략하게 설명해보세요"},
+    ])
+
     return (
-        <div>인터뷰 리스트입니다</div>
+        <div>
+            <Section>
+                <Center>
+                    <VStack w = "80%" spacing = {4}> 
+                        <Box 
+                            color = "#5078E7" w = "200px" h = "150px" 
+                            textAlign = "center" lineHeight = "150px"
+                            fontSize = "32px" fontWeight = "bold"
+                        > 
+                            {params.name} 
+                        </Box>
+                        {
+                            interviewList.map(interview => {
+                                return (
+
+                                    <Box key = {interview._id}
+                                        color = "#5078E7" fontWeight = "bold"
+                                        border = "1px solid black" w = "100%" h = "100px" 
+                                        pl = "10px" display = "flex" alignItems = "center"
+                                        border = "5px solid #E6F0FF"
+                                    >
+                                        <Link to = {interview._id}  >{interview.context}</Link>
+                                    </Box>   
+                                    
+                                    
+                                )
+                            })
+                        }
+                    </VStack>
+                </Center>
+            </Section>
+        </div>
     )
 }
 

--- a/front-end/src/pages/interviewList.jsx
+++ b/front-end/src/pages/interviewList.jsx
@@ -1,6 +1,6 @@
 import React, { useState }  from 'react';
 import { Center, Box, VStack } from "@chakra-ui/react"
-import { useParams, Route, Routes, Link } from "react-router-dom";
+import { useParams, Link, } from "react-router-dom";
 
 import { Section } from '../components/theme/common.style.js';
 import CardNews from "./cardNews.jsx";
@@ -37,7 +37,7 @@ function InterviewList(){
                                         pl = "10px" display = "flex" alignItems = "center"
                                         border = "5px solid #E6F0FF"
                                     >
-                                        <Link to = {interview._id}  >{interview.context}</Link>
+                                        <Link to = {JSON.stringify(interview._id)}>{interview.context}</Link>
                                     </Box>   
                                     
                                     


### PR DESCRIPTION
#24 

## 내용
1. 인터뷰 항목들은 임시로 useState를 이용해서 구성
2. 검은색 글씨는 다크모드일 때 잘 보이지 않아 일단 파란색 글씨로 수정, 
3. 와이어 프레임에서 보이는 것처럼 사진을 보여주는 것 대신 모든 항목에 대해 일단 글씨만 보여주는 식으로 구성하였다. 
4. 더보기 버튼 구현도 생략하였다.

2,3,4의 내용은 일단 추후에 리팩토링하는 과정에서 고치도록 하려고 한다. 
