### PR TITLE
<#8> feat: thumb controller & dto 설계

### DIFF
--- a/back-end/src/main/java/com/j2kb5th/chippo/thumb/controller/ThumbController.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/thumb/controller/ThumbController.java
@@ -1,6 +1,5 @@
 package com.j2kb5th.chippo.thumb.controller;
 
-import com.j2kb5th.chippo.thumb.controller.dto.request.ThumbRequest;
 import com.j2kb5th.chippo.thumb.controller.dto.response.CheckThumbResponse;
 import com.j2kb5th.chippo.thumb.controller.dto.response.ThumbResponse;
 import lombok.RequiredArgsConstructor;
@@ -20,8 +19,7 @@ public class ThumbController {
     @PostMapping("/thumbs")
     public ResponseEntity<ThumbResponse> saveThumb(
             UriComponentsBuilder uriBuilder,
-            @PathVariable(name = "interviewId") Long interviewId,
-            @Valid @RequestBody ThumbRequest thumbRequest
+            @PathVariable(name = "interviewId") Long interviewId
     ){
         ThumbResponse testResponse = new ThumbResponse((123L), LocalDateTime.now());
 

--- a/back-end/src/main/java/com/j2kb5th/chippo/thumb/controller/ThumbController.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/thumb/controller/ThumbController.java
@@ -1,0 +1,51 @@
+package com.j2kb5th.chippo.thumb.controller;
+
+import com.j2kb5th.chippo.thumb.controller.dto.request.ThumbRequest;
+import com.j2kb5th.chippo.thumb.controller.dto.response.CheckThumbResponse;
+import com.j2kb5th.chippo.thumb.controller.dto.response.ThumbResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.validation.Valid;
+import java.net.URI;
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/interviews/{interviewId}")
+@RestController
+public class ThumbController {
+
+    @PostMapping("/thumbs")
+    public ResponseEntity<ThumbResponse> saveThumb(
+            UriComponentsBuilder uriBuilder,
+            @PathVariable(name = "interviewId") Long interviewId,
+            @Valid @RequestBody ThumbRequest thumbRequest
+    ){
+        ThumbResponse testResponse = new ThumbResponse((123L), LocalDateTime.now());
+
+        URI uri = uriBuilder.path("/api/interviews/{interviewId}").build().toUri();
+        return ResponseEntity.created(uri).body(testResponse);
+    }
+
+    @DeleteMapping("/thumbs/{thumbId}")
+    public ResponseEntity<Void> deleteThumb(
+            @PathVariable(name = "interviewId") Long interviewId,
+            @PathVariable(name = "thumbId") Long thumbId
+    ){
+        return ResponseEntity.noContent().build();
+    }
+
+    // 특정 인터뷰에 대해 유저의 따봉 여부 판단
+    // interview 조회 시 줄 예정이지만, 혹시 몰라 추가함
+    @GetMapping("/users/{userId}/thumbs")
+    public ResponseEntity<CheckThumbResponse> checkThumb (
+        @PathVariable(name = "interviewId") Long interviewId,
+        @PathVariable(name = "userId") Long userId
+    ){
+        ThumbResponse testThumbResponse = new ThumbResponse(123L, LocalDateTime.now());
+        CheckThumbResponse testCheckResponse = new CheckThumbResponse(false, testThumbResponse);
+        return ResponseEntity.ok(testCheckResponse);
+    }
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/thumb/controller/dto/request/ThumbRequest.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/thumb/controller/dto/request/ThumbRequest.java
@@ -1,0 +1,4 @@
+package com.j2kb5th.chippo.thumb.controller.dto.request;
+
+public class ThumbRequest {
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/thumb/controller/dto/request/ThumbRequest.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/thumb/controller/dto/request/ThumbRequest.java
@@ -1,4 +1,0 @@
-package com.j2kb5th.chippo.thumb.controller.dto.request;
-
-public class ThumbRequest {
-}

--- a/back-end/src/main/java/com/j2kb5th/chippo/thumb/controller/dto/response/CheckThumbResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/thumb/controller/dto/response/CheckThumbResponse.java
@@ -8,11 +8,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CheckThumbResponse {
 
-    private final boolean thumbsUp;
+    private final boolean clicked;
     private final ThumbResponse thumb;
 
-    public CheckThumbResponse(boolean thumbsUp, Thumb thumb) {
-        this.thumbsUp = thumbsUp;
+    public CheckThumbResponse(boolean clicked, Thumb thumb) {
+        this.clicked = clicked;
         this.thumb = new ThumbResponse(thumb);
     }
 }

--- a/back-end/src/main/java/com/j2kb5th/chippo/thumb/controller/dto/response/CheckThumbResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/thumb/controller/dto/response/CheckThumbResponse.java
@@ -1,0 +1,18 @@
+package com.j2kb5th.chippo.thumb.controller.dto.response;
+
+import com.j2kb5th.chippo.thumb.domain.Thumb;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CheckThumbResponse {
+
+    private final boolean thumbsUp;
+    private final ThumbResponse thumb;
+
+    public CheckThumbResponse(boolean thumbsUp, Thumb thumb) {
+        this.thumbsUp = thumbsUp;
+        this.thumb = new ThumbResponse(thumb);
+    }
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/thumb/controller/dto/response/ThumbResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/thumb/controller/dto/response/ThumbResponse.java
@@ -1,0 +1,23 @@
+package com.j2kb5th.chippo.thumb.controller.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.j2kb5th.chippo.thumb.domain.Thumb;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor // 더미데이터용 (추후 삭제)
+public class ThumbResponse {
+
+    private final Long id;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private final LocalDateTime createdAt;
+
+    public ThumbResponse(Thumb thumb) {
+        this.id = thumb.getId();
+        this.createdAt = thumb.getCreatedAt();
+    }
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/thumb/repository/ThumbRepository.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/thumb/repository/ThumbRepository.java
@@ -1,0 +1,7 @@
+package com.j2kb5th.chippo.thumb.repository;
+
+import com.j2kb5th.chippo.thumb.domain.Thumb;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ThumbRepository extends JpaRepository<Thumb, Long> {
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/thumb/service/ThumbService.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/thumb/service/ThumbService.java
@@ -1,0 +1,4 @@
+package com.j2kb5th.chippo.thumb.service;
+
+public interface ThumbService {
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/thumb/service/ThumbServiceImpl.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/thumb/service/ThumbServiceImpl.java
@@ -1,0 +1,11 @@
+package com.j2kb5th.chippo.thumb.service;
+
+import com.j2kb5th.chippo.thumb.repository.ThumbRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ThumbServiceImpl implements ThumbService {
+    private final ThumbRepository thumbRepository;
+}


### PR DESCRIPTION
## 내용
- Thumb 도메인의 controller & dto를 설계하였습니다.
- Thumb: 기존 `Like` (좋아요)

## 참고
- 기존 api 설계와 달라진 점: thumb 여부 체크 api에서 `thumbers` 단어가 어색하여 관계 표현에 적절한 `/api/interviews/{interviewId}/users/{userId}/thumbs`로 변경

## 이슈
resolve #8 