### PR TITLE
<#31> feat: admin controller & dto 설계

### DIFF
--- a/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/AdminController.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/AdminController.java
@@ -1,0 +1,147 @@
+package com.j2kb5th.chippo.admin.controller;
+
+import com.j2kb5th.chippo.admin.controller.dto.request.AdminInterviewRequest;
+import com.j2kb5th.chippo.admin.controller.dto.response.*;
+import com.j2kb5th.chippo.admin.controller.dto.request.AdminUserRequest;
+import com.j2kb5th.chippo.global.controller.dto.UserResponse;
+import com.j2kb5th.chippo.tag.domain.TagType;
+import com.j2kb5th.chippo.user.domain.Provider;
+import com.j2kb5th.chippo.user.domain.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/admin")
+@RestController
+public class AdminController {
+
+    @GetMapping("/users")
+    public ResponseEntity<AdminUserListResponse> findAllUsersWithAdmin(){
+        List<AdminUserResponse> testUsers = new ArrayList<>();
+
+        List<AdminThumbResponse> testThumb = new ArrayList<>();
+        testThumb.add(new AdminThumbResponse(11L, 3L, LocalDateTime.now()));
+        testThumb.add(new AdminThumbResponse(12L, 4L, LocalDateTime.now()));
+        testThumb.add(new AdminThumbResponse(13L, 5L, LocalDateTime.now()));
+        testThumb.add(new AdminThumbResponse(14L, 6L, LocalDateTime.now()));
+
+        testUsers.add(new AdminUserResponse(123L, "개발곰발","test1@test.com", null,
+                Role.USER, Provider.GOOGLE, false, new ArrayList<>()));
+        testUsers.add(new AdminUserResponse(124L, "발발개발", "test2@test.com", null,
+                Role.BLOCKED, Provider.NAVER, true, new ArrayList<>()));
+        testUsers.add(new AdminUserResponse(125L, "손발개발", "test3@test.com", null,
+                Role.USER, Provider.NAVER, false, new ArrayList<>()));
+        testUsers.add(new AdminUserResponse(126L, "곰곰문문", "test4@test.com", "보통은해시값이지만일단넣어봄",
+                Role.ADMIN, Provider.GOOGLE, false, new ArrayList<>()));
+        AdminUserListResponse testUserListResponse = new AdminUserListResponse(testUsers);
+        return ResponseEntity.ok(testUserListResponse);
+    }
+
+    @PutMapping("/users/{userId}")
+    public ResponseEntity<UpdateAdminUserResponse> updateUserWithAdmin(
+            @PathVariable(name = "userId") Long userId,
+            @Valid @RequestBody AdminUserRequest userRequest
+    ){
+        UpdateAdminUserResponse testUserResponse = new UpdateAdminUserResponse(123L, "개발곰발",
+                "test@test.com", null, Role.USER, Provider.GOOGLE, false);
+        return ResponseEntity.ok(testUserResponse);
+    }
+
+    @DeleteMapping("/users/{userId}")
+    public ResponseEntity<Void> deleteUserWithAdmin(
+            @PathVariable(name = "userId") Long userId
+    ){
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/interviews")
+    public ResponseEntity<AdminInterviewListResponse> findAllInterviewsWithAdmin(){
+        UserResponse testUser1 = new UserResponse(123L, "개발곰발");
+        UserResponse testUser2 = new UserResponse(124L, "개발새발");
+        UserResponse testUser3 = new UserResponse(125L, "개발닭발");
+        UserResponse testUser4 = new UserResponse(126L, "개발양발");
+
+        List<AdminTagDetailResponse> testTag1 = new ArrayList<>();
+        testTag1.add(new AdminTagDetailResponse(1L, TagType.TECHSTACK, "java"));
+        testTag1.add(new AdminTagDetailResponse(2L, TagType.COMPANY, "네이버"));
+        testTag1.add(new AdminTagDetailResponse(3L, TagType.POSITION, "백엔드"));
+
+        List<AdminTagDetailResponse> testTag2 = new ArrayList<>();
+        testTag2.add(new AdminTagDetailResponse(1L, TagType.TECHSTACK, "reactjs"));
+        testTag2.add(new AdminTagDetailResponse(2L, TagType.COMPANY, "카카오"));
+        testTag2.add(new AdminTagDetailResponse(3L, TagType.POSITION, "프론트엔드"));
+
+        List<AdminTagDetailResponse> testTag3 = new ArrayList<>();
+        testTag3.add(new AdminTagDetailResponse(1L, TagType.TECHSTACK, "nodejs"));
+        testTag3.add(new AdminTagDetailResponse(2L, TagType.COMPANY, "네이버"));
+        testTag3.add(new AdminTagDetailResponse(3L, TagType.POSITION, "백엔드"));
+
+
+
+        List<AdminInterviewResponse> testInterviews = new ArrayList<>();
+        testInterviews.add(new AdminInterviewResponse(1111L,
+                testUser1,
+                "JVM의 정의와 장단점을 서술하세요", "JVM은 짱짱 멋진 것임",
+                "면접관님이 후드티 입음",
+                testTag1,
+                new ArrayList<>(),
+                new ArrayList<>()
+        ));
+
+        testInterviews.add(new AdminInterviewResponse(1222L,
+                testUser2,
+                "SPA의 원리를 브라우저 렌더링 순서에 따라 서술하세요", "어쩌구저쩌구",
+                "회사 위치가 복잡함",
+                testTag2,
+                new ArrayList<>(),
+                new ArrayList<>()
+        ));
+
+        testInterviews.add(new AdminInterviewResponse(1333L,
+                testUser3,
+                "npm, parcel, deno는 뭘까요?", "npm은~~~ parcel은... deno는!!!!!",
+                "다음에 손코딩 문제 시킴",
+                testTag3,
+                new ArrayList<>(),
+                new ArrayList<>()
+        ));
+
+        return ResponseEntity.ok(new AdminInterviewListResponse(testInterviews));
+    }
+
+    @PutMapping("/interviews/{interviewId}")
+    public ResponseEntity<UpdateAdminInterviewResponse> updateInterviewWithAdmin(
+            @PathVariable(name = "interviewId") Long interviewId,
+            @Valid @RequestBody AdminInterviewRequest interviewRequest
+    ){
+        List<AdminTagDetailResponse> testTag1 = new ArrayList<>();
+        testTag1.add(new AdminTagDetailResponse(1L, TagType.TECHSTACK, "java"));
+        testTag1.add(new AdminTagDetailResponse(2L, TagType.COMPANY, "네이버"));
+        testTag1.add(new AdminTagDetailResponse(3L, TagType.POSITION, "백엔드"));
+
+        UserResponse testUser1 = new UserResponse(123L, "개발곰발");
+        testTag1.add(new AdminTagDetailResponse(1L, TagType.TECHSTACK, "java"));
+
+        UpdateAdminInterviewResponse testInterviewResponse = new UpdateAdminInterviewResponse(
+                1111L,
+                testUser1,
+                "JVM의 정의와 장단점을 서술하세요", "JVM은 짱짱 멋진 것임",
+                "면접관님이 후드티 입음"
+        );
+        return ResponseEntity.ok(testInterviewResponse);
+    }
+
+
+    @DeleteMapping("/interviews/{interviewId}")
+    public ResponseEntity<Void> deleteInterviewWithAdmin(
+            @PathVariable(name = "interviewId") Long interviewId
+    ){
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/request/AdminInterviewRequest.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/request/AdminInterviewRequest.java
@@ -1,0 +1,21 @@
+package com.j2kb5th.chippo.admin.controller.dto.request;
+
+import com.j2kb5th.chippo.global.controller.dto.UserResponse;
+import lombok.Getter;
+
+import javax.validation.constraints.Size;
+
+@Getter
+public class AdminInterviewRequest {
+    private Long id;
+    private Long userId;
+
+    @Size(max = 150)
+    private String question;
+
+    @Size(max = 300)
+    private String answer;
+
+    @Size(max = 300)
+    private String extraInfo;
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/request/AdminUserRequest.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/request/AdminUserRequest.java
@@ -1,0 +1,4 @@
+package com.j2kb5th.chippo.admin.controller.dto.request;
+
+public class AdminUserRequest {
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/response/AdminCommentResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/response/AdminCommentResponse.java
@@ -1,0 +1,25 @@
+package com.j2kb5th.chippo.admin.controller.dto.response;
+
+import com.j2kb5th.chippo.comment.domain.Comment;
+import com.j2kb5th.chippo.global.controller.dto.UserResponse;
+import com.j2kb5th.chippo.interview.domain.Interview;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor // 임시용
+@Getter
+public class AdminCommentResponse {
+    private final Long id;
+    private final UserResponse user;
+    private final String content;
+    private final LocalDateTime createdAt;
+
+    public AdminCommentResponse(Comment comment){
+        this.id = comment.getId();
+        this.user = new UserResponse(comment.getUser());
+        this.content = comment.getContent();
+        this.createdAt = comment.getCreatedAt();
+    }
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/response/AdminInterviewListResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/response/AdminInterviewListResponse.java
@@ -1,0 +1,23 @@
+package com.j2kb5th.chippo.admin.controller.dto.response;
+
+import com.j2kb5th.chippo.interview.domain.Interview;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor // 임시용
+public class AdminInterviewListResponse {
+    private final List<AdminInterviewResponse> interviews;
+
+//    public AdminInterviewListResponse(List<Interview> interviews){
+//        if (Objects.isNull(interviews)){
+//            // 처리 필요
+//        }
+//        this.interviews = interviews.stream()
+//                .map(AdminInterviewResponse::new)
+//                .collect(Collectors.toList());
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/response/AdminInterviewResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/response/AdminInterviewResponse.java
@@ -1,0 +1,43 @@
+package com.j2kb5th.chippo.admin.controller.dto.response;
+
+import com.j2kb5th.chippo.global.controller.dto.UserResponse;
+import com.j2kb5th.chippo.interview.domain.Interview;
+import com.j2kb5th.chippo.user.domain.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor // 임시용
+public class AdminInterviewResponse {
+
+    private final Long id;
+    private final UserResponse user;
+    private final String question;
+    private final String answer;
+    private final String extraInfo;
+    private final List<AdminTagDetailResponse> interviewTags;
+    private final List<AdminThumbResponse> thumbs;
+    private final List<AdminCommentResponse> comments;
+
+    public AdminInterviewResponse(Interview interview) {
+        if (Objects.isNull(interview)){
+            // 처리 필요
+        }
+        this.id = interview.getId();
+        this.user = new UserResponse(interview.getUser());
+        this.question = interview.getQuestion();
+        this.answer = interview.getAnswer();
+        this.extraInfo = interview.getExtraInfo();
+        this.interviewTags = interview.getInterviewTags().stream()
+                .map((interviewTag) -> new AdminTagDetailResponse(interviewTag.getTag()))
+                .collect(Collectors.toList());
+        this.thumbs = interview.getThumbs().stream()
+                .map(AdminThumbResponse::new).collect(Collectors.toList());
+        this.comments = interview.getComments().stream()
+                .map(AdminCommentResponse::new).collect(Collectors.toList());
+    }
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/response/AdminTagDetailResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/response/AdminTagDetailResponse.java
@@ -1,0 +1,20 @@
+package com.j2kb5th.chippo.admin.controller.dto.response;
+
+import com.j2kb5th.chippo.tag.domain.Tag;
+import com.j2kb5th.chippo.tag.domain.TagType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor // 테스트용
+@Getter
+public class AdminTagDetailResponse {
+    private final Long id;
+    private final TagType type;
+    private final String name;
+
+    public AdminTagDetailResponse(Tag tag){
+        this.id = tag.getId();
+        this.type = tag.getType();
+        this.name = tag.getName();
+    }
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/response/AdminThumbResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/response/AdminThumbResponse.java
@@ -1,0 +1,24 @@
+package com.j2kb5th.chippo.admin.controller.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.j2kb5th.chippo.thumb.domain.Thumb;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Getter
+public class AdminThumbResponse {
+    private final Long id;
+
+    private final Long interviewId;
+
+    @JsonFormat(pattern = "yyyy-NN-dd`T`HH:mm:ss", timezone = "Asia/Seoul")
+    private final LocalDateTime createdAt;
+
+    public AdminThumbResponse(Thumb thumb){
+        this.id = thumb.getId();
+        this.interviewId = thumb.getInterview().getId(); // 처리 필요
+        this.createdAt = thumb.getCreatedAt();
+    }
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/response/AdminUserListResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/response/AdminUserListResponse.java
@@ -1,0 +1,20 @@
+package com.j2kb5th.chippo.admin.controller.dto.response;
+
+import com.j2kb5th.chippo.user.domain.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor // 임시용
+public class AdminUserListResponse {
+
+    private final List<AdminUserResponse> users;
+
+//    public AdminUserListResponse(List<User> user){
+//        this.users = user.stream()
+//                .map(AdminUserResponse::new).collect(Collectors.toList());
+//    }
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/response/AdminUserResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/response/AdminUserResponse.java
@@ -1,0 +1,46 @@
+package com.j2kb5th.chippo.admin.controller.dto.response;
+
+import com.j2kb5th.chippo.global.controller.dto.UserResponse;
+import com.j2kb5th.chippo.user.domain.Provider;
+import com.j2kb5th.chippo.user.domain.Role;
+import com.j2kb5th.chippo.user.domain.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import javax.persistence.Embedded;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor // 임시
+public class AdminUserResponse {
+
+    private final Long id;
+    private final String nickname;
+    private final String email;
+    private final String password;
+    private final Role role;
+    private final Provider provider;
+    private final boolean deleted;
+    private final List<AdminThumbResponse> thumbs;
+
+    public AdminUserResponse(User user){
+        this.id = user.getId();
+        this.nickname = user.getNickname();
+        this.email = user.getEmail();
+        this.password = user.getPassword();
+        this.role = user.getRole();
+        this.provider = user.getProvider();
+        this.deleted = user.isDeleted();
+        if (Objects.isNull(user.getThumbs())){
+            // 처리
+        }
+        this.thumbs = user.getThumbs().stream()
+                .map(AdminThumbResponse::new).collect(Collectors.toList());
+    }
+}
+
+
+

--- a/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/response/UpdateAdminInterviewResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/response/UpdateAdminInterviewResponse.java
@@ -1,0 +1,26 @@
+package com.j2kb5th.chippo.admin.controller.dto.response;
+
+import com.j2kb5th.chippo.global.controller.dto.UserResponse;
+import com.j2kb5th.chippo.interview.domain.Interview;
+import com.j2kb5th.chippo.user.domain.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UpdateAdminInterviewResponse {
+    private final Long id;
+    private final UserResponse user;
+    private final String question;
+    private final String answer;
+    private final String extraInfo;
+
+    public UpdateAdminInterviewResponse(Interview interview){
+        // 예외처리
+        this.id = interview.getId();
+        this.user = new UserResponse(interview.getUser());
+        this.question = interview.getQuestion();
+        this.answer = interview.getAnswer();
+        this.extraInfo = interview.getExtraInfo();
+    }
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/response/UpdateAdminUserResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/response/UpdateAdminUserResponse.java
@@ -1,0 +1,29 @@
+package com.j2kb5th.chippo.admin.controller.dto.response;
+
+import com.j2kb5th.chippo.user.domain.Provider;
+import com.j2kb5th.chippo.user.domain.Role;
+import com.j2kb5th.chippo.user.domain.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor // 추후 제거
+@Getter
+public class UpdateAdminUserResponse {
+    private final Long id;
+    private final String nickname;
+    private final String email;
+    private final String password;
+    private final Role role;
+    private final Provider provider;
+    private final boolean deleted;
+
+    public UpdateAdminUserResponse(User user) {
+        this.id = user.getId();
+        this.nickname = user.getNickname();
+        this.email = user.getEmail();
+        this.password = user.getPassword();
+        this.role = user.getRole();
+        this.provider = user.getProvider();
+        this.deleted = user.isDeleted();
+    }
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/admin/service/AdminService.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/admin/service/AdminService.java
@@ -1,0 +1,4 @@
+package com.j2kb5th.chippo.admin.service;
+
+public interface AdminService {
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/admin/service/AdminServiceImpl.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/admin/service/AdminServiceImpl.java
@@ -1,0 +1,20 @@
+package com.j2kb5th.chippo.admin.service;
+
+import com.j2kb5th.chippo.comment.repository.CommentRepository;
+import com.j2kb5th.chippo.interview.repository.InterviewRepository;
+import com.j2kb5th.chippo.preanswer.repository.PreAnswerRepository;
+import com.j2kb5th.chippo.tag.repository.TagRepository;
+import com.j2kb5th.chippo.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class AdminServiceImpl implements AdminService {
+
+    private final UserRepository userRepository;
+    private final InterviewRepository interviewRepository;
+    private final TagRepository tagRepository;
+    private final CommentRepository commentRepository;
+    private final PreAnswerRepository preAnswerRepository;
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewCommentResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewCommentResponse.java
@@ -21,6 +21,7 @@ public class InterviewCommentResponse {
     private final LocalDateTime updatedAt;
 
     public InterviewCommentResponse(Comment comment) {
+        // 예외처리
         this.id = comment.getId();
         this.user = new UserResponse(comment.getUser());
         this.content = comment.getContent();

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewDetailResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewDetailResponse.java
@@ -37,7 +37,9 @@ public class InterviewDetailResponse {
         this.extraInfo = interview.getExtraInfo();
         this.preAnswer = new InterviewPreAnswerResponse(preAnswer);
         this.thumb = new InterviewThumbResponse(thumbClicked, interview.getThumbs().stream().count());
-        this.interviewTags = interview.getInterviewTags().stream().map(InterviewTagDetailResponse::new).collect(Collectors.toList());
+        this.interviewTags = interview.getInterviewTags().stream()
+                .map((interviewTag) -> new InterviewTagDetailResponse(interviewTag.getTag()))
+                .collect(Collectors.toList());
         this.comments = interview.getComments().stream().map(InterviewCommentResponse::new).collect(Collectors.toList());
         this.updatedAt = interview.getUpdatedAt();
     }

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewResponse.java
@@ -28,7 +28,9 @@ public class InterviewResponse {
         this.id = interview.getId();
         this.user = new UserResponse(interview.getUser());
         this.question = interview.getQuestion();
-        this.interviewTags = interview.getInterviewTags().stream().map(InterviewTagDetailResponse::new).collect(Collectors.toList());
+        this.interviewTags = interview.getInterviewTags().stream()
+                .map((interviewTag) -> new InterviewTagDetailResponse(interviewTag.getTag()))
+                .collect(Collectors.toList());
         this.thumbCount = interview.getThumbs().stream().count();
         this.updatedAt = interview.getUpdatedAt();
     }

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewTagDetailResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewTagDetailResponse.java
@@ -1,6 +1,7 @@
 package com.j2kb5th.chippo.interview.controller.dto.response;
 
 import com.j2kb5th.chippo.tag.domain.InterviewTag;
+import com.j2kb5th.chippo.tag.domain.Tag;
 import com.j2kb5th.chippo.tag.domain.TagType;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -13,10 +14,10 @@ public class InterviewTagDetailResponse {
     private final TagType type;
     private final String name;
 
-    public InterviewTagDetailResponse(InterviewTag interviewTag){
+    public InterviewTagDetailResponse(Tag tag){
         // 예외처리 필요
-        this.id = interviewTag.getTag().getId();
-        this.type = interviewTag.getTag().getType();
-        this.name = interviewTag.getTag().getName();
+        this.id = tag.getId();
+        this.type = tag.getType();
+        this.name = tag.getName();
     }
 }

--- a/back-end/src/main/java/com/j2kb5th/chippo/user/domain/User.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/user/domain/User.java
@@ -43,7 +43,7 @@ public class User extends BaseTimeEntity {
     private boolean deleted;
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
-    private List<Thumb> likes = new ArrayList<>();
+    private List<Thumb> thumbs = new ArrayList<>();
 
     @Builder
     public User(String email, String password, String nickname, Role role, Provider provider) {


### PR DESCRIPTION
## 내용
- admin 관련 controller & dto를 설계
- 관리자 페이지의 user, interview의 전체조회/수정/삭제 api로 구성
- 관련된 도메인의 모든 정보들도 일부씩 리턴하도록 처리


## 논의사항
- comment, tag, preanswer, thumb의 생성/수정/삭제 등도 고려할 필요가 있을 것 같습니다.
- admin은 말 그대로 관리자 페이지여서, 모든 데이터를 조작할 수 있어야 하지 않을까요?
- 또한, 현재 구현 예정인 interview / user의 정렬, 검색 관련 기능은 (추후) 어떻게 할지도 고민입니다.
- 프론트엔드 css 프레임워크에서 이를 일부 지원해주는 걸로 알고 있어서, 일단은 프론트님께도 부탁드리는 게 좋을 것 같습니다!
- 당연히 데이터가 많아지면(n천 건, n만 건) 저희가 처리해서 보내줘야겠지만요...

## 이슈
resolve #31