### PR TITLE
<#32> feat: swagger3(api 문서 자동화툴) 추가

### DIFF
--- a/back-end/build.gradle
+++ b/back-end/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springdoc:springdoc-openapi-ui:1.5.13' // swagger3
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/AdminController.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/AdminController.java
@@ -7,6 +7,9 @@ import com.j2kb5th.chippo.global.controller.dto.UserResponse;
 import com.j2kb5th.chippo.tag.domain.TagType;
 import com.j2kb5th.chippo.user.domain.Provider;
 import com.j2kb5th.chippo.user.domain.Role;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,11 +19,13 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+@Tag(name = "관리자(Admin)", description = "관리자 API")
 @RequiredArgsConstructor
 @RequestMapping("/api/admin")
 @RestController
 public class AdminController {
 
+    @Operation(summary = "전체 유저 조회", description = "전체 유저 정보를 조회합니다.")
     @GetMapping("/users")
     public ResponseEntity<AdminUserListResponse> findAllUsersWithAdmin(){
         List<AdminUserResponse> testUsers = new ArrayList<>();
@@ -43,9 +48,10 @@ public class AdminController {
         return ResponseEntity.ok(testUserListResponse);
     }
 
+    @Operation(summary = "유저 정보 수정", description = "id를 이용하여 유저 정보를 수정합니다.")
     @PutMapping("/users/{userId}")
     public ResponseEntity<UpdateAdminUserResponse> updateUserWithAdmin(
-            @PathVariable(name = "userId") Long userId,
+            @Parameter(description = "유저 ID") @PathVariable(name = "userId") Long userId,
             @Valid @RequestBody AdminUserRequest userRequest
     ){
         UpdateAdminUserResponse testUserResponse = new UpdateAdminUserResponse(123L, "개발곰발",
@@ -53,13 +59,15 @@ public class AdminController {
         return ResponseEntity.ok(testUserResponse);
     }
 
+    @Operation(summary = "유저 삭제", description = "id를 이용하여 유저를 삭제합니다(실제 삭제X, 삭제여부를 1로 변경)")
     @DeleteMapping("/users/{userId}")
     public ResponseEntity<Void> deleteUserWithAdmin(
-            @PathVariable(name = "userId") Long userId
+            @Parameter(description = "유저 ID") @PathVariable(name = "userId") Long userId
     ){
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "전체 기술면접 조회", description = "전체 기술면접 게시글 목록을 조회합니다.")
     @GetMapping("/interviews")
     public ResponseEntity<AdminInterviewListResponse> findAllInterviewsWithAdmin(){
         UserResponse testUser1 = new UserResponse(123L, "개발곰발");
@@ -115,9 +123,10 @@ public class AdminController {
         return ResponseEntity.ok(new AdminInterviewListResponse(testInterviews));
     }
 
+    @Operation(summary = "기술면접 정보 수정", description = "id를 이용하여 기술면접 정보를 수정합니다.")
     @PutMapping("/interviews/{interviewId}")
     public ResponseEntity<UpdateAdminInterviewResponse> updateInterviewWithAdmin(
-            @PathVariable(name = "interviewId") Long interviewId,
+            @Parameter(description = "기술면접 ID") @PathVariable(name = "interviewId") Long interviewId,
             @Valid @RequestBody AdminInterviewRequest interviewRequest
     ){
         List<AdminTagDetailResponse> testTag1 = new ArrayList<>();
@@ -129,18 +138,18 @@ public class AdminController {
         testTag1.add(new AdminTagDetailResponse(1L, TagType.TECHSTACK, "java"));
 
         UpdateAdminInterviewResponse testInterviewResponse = new UpdateAdminInterviewResponse(
-                1111L,
+                interviewId,
                 testUser1,
-                "JVM의 정의와 장단점을 서술하세요", "JVM은 짱짱 멋진 것임",
-                "면접관님이 후드티 입음"
+                interviewRequest.getQuestion(), interviewRequest.getAnswer(),
+                interviewRequest.getExtraInfo()
         );
         return ResponseEntity.ok(testInterviewResponse);
     }
 
-
+    @Operation(summary = "기술면접 삭제", description = "id를 이용하여 기술면접 게시글을 삭제합니다(실제 삭제)")
     @DeleteMapping("/interviews/{interviewId}")
     public ResponseEntity<Void> deleteInterviewWithAdmin(
-            @PathVariable(name = "interviewId") Long interviewId
+            @Parameter(description = "기술면접 ID") @PathVariable(name = "interviewId") Long interviewId
     ){
         return ResponseEntity.noContent().build();
     }

--- a/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/request/AdminInterviewRequest.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/request/AdminInterviewRequest.java
@@ -1,21 +1,31 @@
 package com.j2kb5th.chippo.admin.controller.dto.request;
 
-import com.j2kb5th.chippo.global.controller.dto.UserResponse;
 import lombok.Getter;
 
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 @Getter
 public class AdminInterviewRequest {
+
+    @NotNull
     private Long id;
+
+    @NotNull
     private Long userId;
 
     @Size(max = 150)
+    @NotEmpty
     private String question;
 
     @Size(max = 300)
+    @NotEmpty
     private String answer;
 
     @Size(max = 300)
+    @NotEmpty
     private String extraInfo;
+
+    // 인터뷰 태그 정보
 }

--- a/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/request/AdminUserRequest.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/request/AdminUserRequest.java
@@ -1,4 +1,29 @@
 package com.j2kb5th.chippo.admin.controller.dto.request;
 
+import com.j2kb5th.chippo.user.domain.Provider;
+import com.j2kb5th.chippo.user.domain.Role;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@RequiredArgsConstructor // 임시
+@Getter
 public class AdminUserRequest {
+
+    private Long id;
+
+    @NotBlank
+    @Size(max = 20)
+    private String nickname;
+
+    @Email
+    @Size(max = 50)
+    private String email;
+
+    private Role role;
+    private Provider provider;
+    private boolean deleted;
 }

--- a/back-end/src/main/java/com/j2kb5th/chippo/comment/controller/CommentController.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/comment/controller/CommentController.java
@@ -5,6 +5,9 @@ import com.j2kb5th.chippo.comment.controller.dto.reponse.CommentListResponse;
 import com.j2kb5th.chippo.comment.controller.dto.request.CommentRequest;
 import com.j2kb5th.chippo.comment.service.CommentService;
 import com.j2kb5th.chippo.global.controller.dto.UserResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,6 +19,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+@Tag(name = "댓글(Comment)", description = "댓글 API")
 @RequiredArgsConstructor
 @RequestMapping("/api/interviews/{interviewId}/comments")
 @RestController
@@ -24,9 +28,11 @@ public class CommentController {
     private final CommentService commentService;
 
     // 페이지네이션 구현할 때만 필요
+    @Operation(summary = "댓글 목록 조회(임시용)",
+            description = "페이지네이션 기능 구현 시 필요한 댓글 목록 조회 기능입니다. 현재는 기술면접 조회 시 댓글 목록이 함께 리턴됩니다.")
     @GetMapping
     public ResponseEntity<CommentListResponse> findComments(
-        @PathVariable(name = "interviewId") Long interviewId
+        @Parameter(description = "기술면접 ID") @PathVariable(name = "interviewId") Long interviewId
     ){
         //// find comments by interview id
         // commentService.findByInterviewId(interviewId);
@@ -56,10 +62,11 @@ public class CommentController {
         return ResponseEntity.ok(new CommentListResponse(comments));
     }
 
+    @Operation(summary = "댓글 저장", description = "요청된 정보를 댓글로 등록합니다.")
     @PostMapping
     public ResponseEntity<CommentResponse> saveComment(
             UriComponentsBuilder uriBuilder,
-            @PathVariable(name = "interviewId") Long interviewId,
+            @Parameter(description = "기술면접 ID") @PathVariable(name = "interviewId") Long interviewId,
             @Valid @RequestBody CommentRequest commentRequest
     ){
         //// save comment & get entity to response
@@ -73,10 +80,11 @@ public class CommentController {
         return ResponseEntity.created(uri).body(commentResponse);
     }
 
+    @Operation(summary = "댓글 수정", description = "id를 이용하여 댓글을 삭제합니다.")
     @DeleteMapping("/{commentId}")
     public ResponseEntity<Void> deleteComment(
-            @PathVariable(name = "interviewId") Long interviewId,
-            @PathVariable(name = "commentId") Long commentId
+            @Parameter(description = "기술면접 ID") @PathVariable(name = "interviewId") Long interviewId,
+            @Parameter(description = "댓글 ID") @PathVariable(name = "commentId") Long commentId
     ){
         //// delete comment
         // commentService.delete(interviewId, commentId);

--- a/back-end/src/main/java/com/j2kb5th/chippo/comment/domain/Comment.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/comment/domain/Comment.java
@@ -3,6 +3,7 @@ package com.j2kb5th.chippo.comment.domain;
 import com.j2kb5th.chippo.global.domain.BaseTimeEntity;
 import com.j2kb5th.chippo.interview.domain.Interview;
 import com.j2kb5th.chippo.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;

--- a/back-end/src/main/java/com/j2kb5th/chippo/config/swagger/SwaggerConfig.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/config/swagger/SwaggerConfig.java
@@ -1,0 +1,32 @@
+package com.j2kb5th.chippo.config.swagger;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import org.springdoc.core.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    // basic setting
+    @Bean
+    public OpenAPI chippoAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("CHIPPO API")
+                        .description("CHIPPO api specification")
+                        .contact(new Contact().name("@dadahee, @nrudev"))
+                );
+    }
+
+    @Bean
+    public GroupedOpenApi apiVersion() {
+        return GroupedOpenApi.builder()
+                .group("api-v1")
+                .pathsToExclude("/swagger") // 제외 url
+                .pathsToMatch("/**") // 처리될 url
+                .build();
+    }
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/global/controller/DocumentController.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/global/controller/DocumentController.java
@@ -1,0 +1,15 @@
+package com.j2kb5th.chippo.global.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/swagger")
+public class DocumentController {
+
+    @GetMapping
+    public String redicrectToSwagger(){
+        return "redirect:/swagger-ui.html";
+    }
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/global/domain/BaseTimeEntity.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/global/domain/BaseTimeEntity.java
@@ -1,5 +1,6 @@
 package com.j2kb5th.chippo.global.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/InterviewController.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/InterviewController.java
@@ -9,6 +9,7 @@ import com.j2kb5th.chippo.interview.controller.dto.response.*;
 import com.j2kb5th.chippo.interview.service.InterviewService;
 import com.j2kb5th.chippo.tag.domain.TagType;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -33,7 +34,7 @@ public class InterviewController {
     @Operation(summary = "기술면접 단건 조회", description = "id를 이용하여 기술면접 게시글을 단건 조회합니다.")
     @GetMapping("/{interviewId}")
     public ResponseEntity<InterviewDetailResponse> findInterview(
-            @PathVariable(name = "interviewId") Long interviewId
+            @Parameter(description = "기술면접 ID") @PathVariable(name = "interviewId") Long interviewId
     ){
         List<InterviewCommentResponse> testComments = new ArrayList<>();
         testComments.add(new InterviewCommentResponse(1L, new UserResponse(123L, "카카오꿈나무"),
@@ -138,7 +139,7 @@ public class InterviewController {
     @Operation(summary = "기술면접 수정", description = "id를 이용하여 기술면접 게시글을 수정합니다.")
     @PutMapping("/{interviewId}")
     public ResponseEntity<InterviewDetailResponse> updateInterview(
-            @PathVariable(name = "interviewId") Long interviewId,
+            @Parameter(description = "기술면접 ID") @PathVariable(name = "interviewId") Long interviewId,
             @Valid @RequestBody UpdateInterviewRequest interviewRequest
     ){
         List<InterviewCommentResponse> testComments = new ArrayList<>();
@@ -173,7 +174,7 @@ public class InterviewController {
     @Operation(summary = "기술면접 삭제", description = "id를 이용해 기술면접 게시글을 삭제합니다. (실제 삭제)")
     @DeleteMapping("/{interviewId}")
     public ResponseEntity<Void> deleteInterview(
-            @PathVariable(name = "interviewId") Long interviewId
+            @Parameter(description = "기술면접 ID") @PathVariable(name = "interviewId") Long interviewId
     ){
         return ResponseEntity.noContent().build();
     }

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/InterviewController.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/InterviewController.java
@@ -8,11 +8,14 @@ import com.j2kb5th.chippo.interview.controller.dto.request.UpdateInterviewTagDet
 import com.j2kb5th.chippo.interview.controller.dto.response.*;
 import com.j2kb5th.chippo.interview.service.InterviewService;
 import com.j2kb5th.chippo.tag.domain.TagType;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import javax.validation.Valid;
 import java.net.URI;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -20,12 +23,14 @@ import java.util.Arrays;
 import java.util.List;
 
 
+@Tag(name = "기술면접(Interview)", description = "기술면접 API")
 @RequiredArgsConstructor
 @RequestMapping("/api/interviews")
 @RestController
 public class InterviewController {
     private final InterviewService interviewService;
 
+    @Operation(summary = "기술면접 단건 조회", description = "id를 이용하여 기술면접 게시글을 단건 조회합니다.")
     @GetMapping("/{interviewId}")
     public ResponseEntity<InterviewDetailResponse> findInterview(
             @PathVariable(name = "interviewId") Long interviewId
@@ -55,6 +60,8 @@ public class InterviewController {
     }
 
 
+    @Operation(summary = "태그 정보로 기술면접 목록 조회",
+            description = "태그명(tag_name), 태그타입(tag_type), 요청할 최대 게시글수(size)를 이용해 기술면접 목록을 조회합니다.")
     @GetMapping
     public ResponseEntity<InterviewListResponse> findInterviewsByTag(
             @RequestParam(name = "tag_name") String tagName,
@@ -97,11 +104,11 @@ public class InterviewController {
         return ResponseEntity.ok(new InterviewListResponse(testInterviews));
     }
 
-
+    @Operation(summary = "기술면접 저장", description = "요청한 정보를 기술면접 게시글로 등록합니다.")
     @PostMapping
     public ResponseEntity<InterviewDetailResponse> saveInterview(
             UriComponentsBuilder uriBuilder,
-            @RequestBody SaveInterviewRequest interviewRequest
+            @Valid @RequestBody SaveInterviewRequest interviewRequest
     ){
         List<InterviewTagDetailResponse> testTags = new ArrayList<>();
         List<SaveInterviewTagDetailRequest> tags = interviewRequest.getInterviewTags();
@@ -128,10 +135,11 @@ public class InterviewController {
     }
 
 
-    @PutMapping
+    @Operation(summary = "기술면접 수정", description = "id를 이용하여 기술면접 게시글을 수정합니다.")
+    @PutMapping("/{interviewId}")
     public ResponseEntity<InterviewDetailResponse> updateInterview(
             @PathVariable(name = "interviewId") Long interviewId,
-            @RequestBody UpdateInterviewRequest interviewRequest
+            @Valid @RequestBody UpdateInterviewRequest interviewRequest
     ){
         List<InterviewCommentResponse> testComments = new ArrayList<>();
         testComments.add(new InterviewCommentResponse(1L, new UserResponse(123L, "카카오꿈나무"),
@@ -162,7 +170,8 @@ public class InterviewController {
         return ResponseEntity.ok(testResponse);
     }
 
-    @DeleteMapping
+    @Operation(summary = "기술면접 삭제", description = "id를 이용해 기술면접 게시글을 삭제합니다. (실제 삭제)")
+    @DeleteMapping("/{interviewId}")
     public ResponseEntity<Void> deleteInterview(
             @PathVariable(name = "interviewId") Long interviewId
     ){

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/domain/Interview.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/domain/Interview.java
@@ -5,6 +5,7 @@ import com.j2kb5th.chippo.global.domain.BaseTimeEntity;
 import com.j2kb5th.chippo.thumb.domain.Thumb;
 import com.j2kb5th.chippo.tag.domain.InterviewTag;
 import com.j2kb5th.chippo.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;

--- a/back-end/src/main/java/com/j2kb5th/chippo/preanswer/controller/PreAnswerController.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/preanswer/controller/PreAnswerController.java
@@ -4,6 +4,8 @@ import com.j2kb5th.chippo.global.controller.dto.UserResponse;
 import com.j2kb5th.chippo.preanswer.controller.dto.request.SavePreAnswerRequest;
 import com.j2kb5th.chippo.preanswer.controller.dto.request.UpdatePreAnswerRequest;
 import com.j2kb5th.chippo.preanswer.controller.dto.response.PreAnswerResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,6 +15,7 @@ import javax.validation.Valid;
 import java.net.URI;
 import java.time.LocalDateTime;
 
+@Tag(name = "사전답안(PreAnswer)", description = "사전답안 API")
 @RequiredArgsConstructor
 @RequestMapping("/api/interviews/{interviewId}/pre-answers")
 @RestController
@@ -20,6 +23,8 @@ public class PreAnswerController {
 
     // 현재는 interview 조회 시 preanswer도 있으면 동시에 전달
     // 혹시 몰라 단건 조회도 첨부
+    @Operation(summary = "사전답안 단건 조회(임시용)",
+            description = "현재는 기술면접 단건 조회 시 등록된 사전답안 게시글이 있다면 함께 전달됩니다. 혹시 몰라 추가해둔 API입니다.")
     @GetMapping("/{preAnswerId}")
     public ResponseEntity<PreAnswerResponse> findPreAnswer(
         @PathVariable(name = "interviewId") Long interviewId
@@ -33,6 +38,7 @@ public class PreAnswerController {
         return ResponseEntity.ok(testPreAnswer);
     }
 
+    @Operation(summary = "사전답안 저장", description = "요청된 정보를 사전답안으로 등록합니다.")
     @PostMapping
     public ResponseEntity<PreAnswerResponse> savePreAnswer(
         UriComponentsBuilder uriBuilder,
@@ -44,6 +50,7 @@ public class PreAnswerController {
         return ResponseEntity.created(uri).body(response);
     }
 
+    @Operation(summary = "사전답안 수정", description = "id를 이용해 사전답안을 수정합니다.")
     @PatchMapping("/{preAnswerId}")
     public ResponseEntity<PreAnswerResponse> updatePreAnswer(
             @PathVariable(name = "interviewId") Long interviewId,
@@ -53,6 +60,7 @@ public class PreAnswerController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "사전답안 삭제", description = "id를 이용해 사전답안을 삭제합니다.")
     @DeleteMapping("/{preAnswerId}")
     public ResponseEntity<Void> deletePreAnswer(
             @PathVariable(name = "interviewId") Long interviewId,

--- a/back-end/src/main/java/com/j2kb5th/chippo/preanswer/controller/PreAnswerController.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/preanswer/controller/PreAnswerController.java
@@ -5,6 +5,7 @@ import com.j2kb5th.chippo.preanswer.controller.dto.request.SavePreAnswerRequest;
 import com.j2kb5th.chippo.preanswer.controller.dto.request.UpdatePreAnswerRequest;
 import com.j2kb5th.chippo.preanswer.controller.dto.response.PreAnswerResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -27,7 +28,7 @@ public class PreAnswerController {
             description = "현재는 기술면접 단건 조회 시 등록된 사전답안 게시글이 있다면 함께 전달됩니다. 혹시 몰라 추가해둔 API입니다.")
     @GetMapping("/{preAnswerId}")
     public ResponseEntity<PreAnswerResponse> findPreAnswer(
-        @PathVariable(name = "interviewId") Long interviewId
+        @Parameter(description = "기술면접 ID") @PathVariable(name = "interviewId") Long interviewId
     ){
         PreAnswerResponse testPreAnswer = new PreAnswerResponse(
                 interviewId,
@@ -42,7 +43,7 @@ public class PreAnswerController {
     @PostMapping
     public ResponseEntity<PreAnswerResponse> savePreAnswer(
         UriComponentsBuilder uriBuilder,
-        @PathVariable(name = "interviewId") Long interviewId,
+        @Parameter(description = "기술면접 ID") @PathVariable(name = "interviewId") Long interviewId,
         @Valid @RequestBody SavePreAnswerRequest preAnswerRequest
     ){
         URI uri = uriBuilder.path("/api/interviews/{interviewId}/pre-answers").buildAndExpand(interviewId).toUri();
@@ -53,8 +54,8 @@ public class PreAnswerController {
     @Operation(summary = "사전답안 수정", description = "id를 이용해 사전답안을 수정합니다.")
     @PatchMapping("/{preAnswerId}")
     public ResponseEntity<PreAnswerResponse> updatePreAnswer(
-            @PathVariable(name = "interviewId") Long interviewId,
-            @Valid @RequestBody UpdatePreAnswerRequest preAnswerRequest
+        @Parameter(description = "기술면접 ID") @PathVariable(name = "interviewId") Long interviewId,
+        @Valid @RequestBody UpdatePreAnswerRequest preAnswerRequest
     ){
         PreAnswerResponse response = new PreAnswerResponse(interviewId, preAnswerRequest.getContent(), new UserResponse(11L, "노드개발자"), LocalDateTime.now());
         return ResponseEntity.ok(response);
@@ -63,8 +64,8 @@ public class PreAnswerController {
     @Operation(summary = "사전답안 삭제", description = "id를 이용해 사전답안을 삭제합니다.")
     @DeleteMapping("/{preAnswerId}")
     public ResponseEntity<Void> deletePreAnswer(
-            @PathVariable(name = "interviewId") Long interviewId,
-            @PathVariable(name = "preAnswerId") Long preAnswerId
+        @Parameter(description = "기술면접 ID") @PathVariable(name = "interviewId") Long interviewId,
+        @Parameter(description = "사전답안 ID") @PathVariable(name = "preAnswerId") Long preAnswerId
     ){
         return ResponseEntity.noContent().build();
     }

--- a/back-end/src/main/java/com/j2kb5th/chippo/preanswer/domain/PreAnswer.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/preanswer/domain/PreAnswer.java
@@ -3,6 +3,7 @@ package com.j2kb5th.chippo.preanswer.domain;
 import com.j2kb5th.chippo.global.domain.BaseTimeEntity;
 import com.j2kb5th.chippo.interview.domain.Interview;
 import com.j2kb5th.chippo.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import javax.persistence.*;

--- a/back-end/src/main/java/com/j2kb5th/chippo/tag/domain/InterviewTag.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/tag/domain/InterviewTag.java
@@ -1,6 +1,7 @@
 package com.j2kb5th.chippo.tag.domain;
 
 import com.j2kb5th.chippo.interview.domain.Interview;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import javax.persistence.*;
@@ -11,6 +12,7 @@ import javax.persistence.*;
 @Getter
 @Entity
 public class InterviewTag {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/back-end/src/main/java/com/j2kb5th/chippo/tag/domain/Tag.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/tag/domain/Tag.java
@@ -1,6 +1,7 @@
 package com.j2kb5th.chippo.tag.domain;
 
 import com.j2kb5th.chippo.interview.domain.Interview;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import javax.persistence.*;

--- a/back-end/src/main/java/com/j2kb5th/chippo/thumb/controller/ThumbController.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/thumb/controller/ThumbController.java
@@ -3,6 +3,7 @@ package com.j2kb5th.chippo.thumb.controller;
 import com.j2kb5th.chippo.thumb.controller.dto.response.CheckThumbResponse;
 import com.j2kb5th.chippo.thumb.controller.dto.response.ThumbResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -23,7 +24,7 @@ public class ThumbController {
     @PostMapping("/thumbs")
     public ResponseEntity<ThumbResponse> saveThumb(
             UriComponentsBuilder uriBuilder,
-            @PathVariable(name = "interviewId") Long interviewId
+            @Parameter(description = "기술면접 ID") @PathVariable(name = "interviewId") Long interviewId
     ){
         ThumbResponse testResponse = new ThumbResponse((123L), LocalDateTime.now());
 
@@ -34,8 +35,8 @@ public class ThumbController {
     @Operation(summary = "따봉 취소", description = "해당 id의 기술면접에서, 해당 id의 따봉(좋아요)을 취소합니다.")
     @DeleteMapping("/thumbs/{thumbId}")
     public ResponseEntity<Void> deleteThumb(
-            @PathVariable(name = "interviewId") Long interviewId,
-            @PathVariable(name = "thumbId") Long thumbId
+            @Parameter(description = "기술면접 ID") @PathVariable(name = "interviewId") Long interviewId,
+            @Parameter(description = "따봉 ID") @PathVariable(name = "thumbId") Long thumbId
     ){
         return ResponseEntity.noContent().build();
     }
@@ -46,8 +47,8 @@ public class ThumbController {
             description = "현재는 기술면조 단건 조회 시 따봉 여부가 함께 전달됩니다. 혹시 몰라 추가해둔 API입니다.")
     @GetMapping("/users/{userId}/thumbs")
     public ResponseEntity<CheckThumbResponse> checkThumb (
-        @PathVariable(name = "interviewId") Long interviewId,
-        @PathVariable(name = "userId") Long userId
+        @Parameter(description = "기술면접 ID") @PathVariable(name = "interviewId") Long interviewId,
+        @Parameter(description = "유저 ID") @PathVariable(name = "userId") Long userId
     ){
         ThumbResponse testThumbResponse = new ThumbResponse(123L, LocalDateTime.now());
         CheckThumbResponse testCheckResponse = new CheckThumbResponse(false, testThumbResponse);

--- a/back-end/src/main/java/com/j2kb5th/chippo/thumb/controller/ThumbController.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/thumb/controller/ThumbController.java
@@ -2,6 +2,8 @@ package com.j2kb5th.chippo.thumb.controller;
 
 import com.j2kb5th.chippo.thumb.controller.dto.response.CheckThumbResponse;
 import com.j2kb5th.chippo.thumb.controller.dto.response.ThumbResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,11 +13,13 @@ import javax.validation.Valid;
 import java.net.URI;
 import java.time.LocalDateTime;
 
+@Tag(name = "따봉(좋아요)", description = "따봉 API")
 @RequiredArgsConstructor
 @RequestMapping("/api/interviews/{interviewId}")
 @RestController
 public class ThumbController {
 
+    @Operation(summary = "따봉 저장", description = "해당 id의 기술면접에 따봉(좋아요)을 등록합니다.")
     @PostMapping("/thumbs")
     public ResponseEntity<ThumbResponse> saveThumb(
             UriComponentsBuilder uriBuilder,
@@ -27,6 +31,7 @@ public class ThumbController {
         return ResponseEntity.created(uri).body(testResponse);
     }
 
+    @Operation(summary = "따봉 취소", description = "해당 id의 기술면접에서, 해당 id의 따봉(좋아요)을 취소합니다.")
     @DeleteMapping("/thumbs/{thumbId}")
     public ResponseEntity<Void> deleteThumb(
             @PathVariable(name = "interviewId") Long interviewId,
@@ -37,6 +42,8 @@ public class ThumbController {
 
     // 특정 인터뷰에 대해 유저의 따봉 여부 판단
     // interview 조회 시 줄 예정이지만, 혹시 몰라 추가함
+    @Operation(summary = "따봉 여부 판단(임시용)",
+            description = "현재는 기술면조 단건 조회 시 따봉 여부가 함께 전달됩니다. 혹시 몰라 추가해둔 API입니다.")
     @GetMapping("/users/{userId}/thumbs")
     public ResponseEntity<CheckThumbResponse> checkThumb (
         @PathVariable(name = "interviewId") Long interviewId,

--- a/back-end/src/main/java/com/j2kb5th/chippo/thumb/domain/Thumb.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/thumb/domain/Thumb.java
@@ -2,6 +2,7 @@ package com.j2kb5th.chippo.thumb.domain;
 
 import com.j2kb5th.chippo.interview.domain.Interview;
 import com.j2kb5th.chippo.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 

--- a/back-end/src/main/java/com/j2kb5th/chippo/user/domain/User.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/user/domain/User.java
@@ -2,6 +2,7 @@ package com.j2kb5th.chippo.user.domain;
 
 import com.j2kb5th.chippo.global.domain.BaseTimeEntity;
 import com.j2kb5th.chippo.thumb.domain.Thumb;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
@@ -17,6 +18,7 @@ import java.util.List;
 @Getter
 @Entity
 public class User extends BaseTimeEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;


### PR DESCRIPTION
## 내용
- Swagger3 의존성 추가
- 컨트롤러 & api별 제목, 설명 추가
- api의 파라미터별 설명 추가
- Swagger3 문서 설정: 제목, 내용, 버전 옵션 추가

## 참고
- 유저 API 명세가 남아서 브랜치는 최종 편집 후에 삭제하겠습니다 ~
- 완성된 부분까지는 빠르게 머지할게요.

## 이슈
resolve #32 