### PR TITLE
<#49> feat: 태그 컨트롤러 및 태그별 목록 조회 api 설계 추가

### DIFF
--- a/back-end/src/main/java/com/j2kb5th/chippo/tag/controller/TagController.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/tag/controller/TagController.java
@@ -1,0 +1,46 @@
+package com.j2kb5th.chippo.tag.controller;
+
+import com.j2kb5th.chippo.tag.controller.dto.response.TagListResponse;
+import com.j2kb5th.chippo.tag.controller.dto.response.TagResponse;
+import com.j2kb5th.chippo.tag.domain.Tag;
+import com.j2kb5th.chippo.tag.domain.TagType;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@io.swagger.v3.oas.annotations.tags.Tag(name = "태그(Tag)", description = "태그 API")
+@RequestMapping("/api/tags")
+@RequiredArgsConstructor
+@RestController
+public class TagController {
+
+    @Operation(summary = "태그타입으로 태그 목록 조회",
+        description = "홈화면에서 사용 - 기업별/직무별/기술스택별로(타입별로) 태그 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<TagListResponse> findByTagType(
+            @Parameter(description = "태그 타입") @RequestParam(name = "type") TagType type
+    ){
+        List<TagResponse> tags = new ArrayList<>();
+        if (type.equals(TagType.TECHSTACK)) {
+            tags.add(new TagResponse(1L, "Spring"));
+            tags.add(new TagResponse(2L, "TypeScript"));
+            tags.add(new TagResponse(3L, "MySQL"));
+        } else if (type.equals(TagType.COMPANY)) {
+            tags.add(new TagResponse(4L,"카카오"));
+            tags.add(new TagResponse(5L,"네이버"));
+            tags.add(new TagResponse(6L,"배달의민족"));
+        } else if (type.equals(TagType.POSITION)) {
+            tags.add(new TagResponse(7L,"프론트엔드"));
+            tags.add(new TagResponse(8L,"백엔드"));
+        }
+        return ResponseEntity.ok(new TagListResponse(type, tags));
+    }
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/tag/controller/dto/response/TagListResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/tag/controller/dto/response/TagListResponse.java
@@ -1,0 +1,24 @@
+package com.j2kb5th.chippo.tag.controller.dto.response;
+
+import com.j2kb5th.chippo.tag.domain.Tag;
+import com.j2kb5th.chippo.tag.domain.TagType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor // 설계용 임시
+public class TagListResponse {
+    private final TagType type;
+    private final List<TagResponse> tags;
+
+    public TagListResponse(List<Tag> tags) {
+        if (tags.isEmpty()) {
+            // 처리
+        }
+        this.type = tags.get(0).getType();
+        this.tags = tags.stream().map(TagResponse::new).collect(Collectors.toList());
+    }
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/tag/controller/dto/response/TagResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/tag/controller/dto/response/TagResponse.java
@@ -1,0 +1,18 @@
+package com.j2kb5th.chippo.tag.controller.dto.response;
+
+import com.j2kb5th.chippo.tag.domain.Tag;
+import com.j2kb5th.chippo.tag.domain.TagType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor // 임시용
+public class TagResponse {
+    private final Long id;
+    private final String name;
+
+    public TagResponse(Tag tag){
+        this.id = tag.getId();
+        this.name = tag.getName();
+    }
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/tag/domain/Tag.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/tag/domain/Tag.java
@@ -28,5 +28,4 @@ public class Tag {
 
     @OneToMany(mappedBy = "interview", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<InterviewTag> interviewTags = new ArrayList<>();
-    
 }


### PR DESCRIPTION
## 내용
- 홈화면에서 기업별/직무별/기술스택별 태그 목록 조회 목적
- 태그 컨트롤러 및 태그 목록조회 api 추가
  - 스웨거 어노테이션과 네이밍 충돌로 인해 스웨거 어노테이션은 import 없이 사용
  - 태그 목록 조회 api
      - 예: `GET /api/tags?type=TECHSTACK`

## 참고
- 인터뷰 API 설계: #7 

## 이슈
- solve #49 
