### PR TITLE
<#50> feat: Interview 조회 기능 구현 및 글로벌 예외처리

### DIFF
--- a/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/response/AdminCommentResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/response/AdminCommentResponse.java
@@ -1,5 +1,6 @@
 package com.j2kb5th.chippo.admin.controller.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.j2kb5th.chippo.comment.domain.Comment;
 import com.j2kb5th.chippo.global.controller.dto.UserResponse;
 import com.j2kb5th.chippo.interview.domain.Interview;
@@ -14,6 +15,8 @@ public class AdminCommentResponse {
     private final Long id;
     private final UserResponse user;
     private final String content;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     private final LocalDateTime createdAt;
 
     public AdminCommentResponse(Comment comment){

--- a/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/response/AdminThumbResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/admin/controller/dto/response/AdminThumbResponse.java
@@ -13,7 +13,7 @@ public class AdminThumbResponse {
 
     private final Long interviewId;
 
-    @JsonFormat(pattern = "yyyy-NN-dd`T`HH:mm:ss", timezone = "Asia/Seoul")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     private final LocalDateTime createdAt;
 
     public AdminThumbResponse(Thumb thumb){

--- a/back-end/src/main/java/com/j2kb5th/chippo/admin/service/AdminServiceImpl.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/admin/service/AdminServiceImpl.java
@@ -12,9 +12,4 @@ import org.springframework.stereotype.Service;
 @Service
 public class AdminServiceImpl implements AdminService {
 
-    private final UserRepository userRepository;
-    private final InterviewRepository interviewRepository;
-    private final TagRepository tagRepository;
-    private final CommentRepository commentRepository;
-    private final PreAnswerRepository preAnswerRepository;
 }

--- a/back-end/src/main/java/com/j2kb5th/chippo/comment/controller/dto/reponse/CommentResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/comment/controller/dto/reponse/CommentResponse.java
@@ -15,7 +15,7 @@ public class CommentResponse {
     private final UserResponse user;
     private final String content;
 
-    @JsonFormat(pattern = "yyyy-MM-dd`T`HH:mm:ss", timezone = "Asia/Seoul")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     private final LocalDateTime updatedAt;
 
     public CommentResponse(Comment comment) {

--- a/back-end/src/main/java/com/j2kb5th/chippo/global/controller/dto/UserResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/global/controller/dto/UserResponse.java
@@ -11,9 +11,6 @@ public class UserResponse {
     private final String nickname;
 
     public UserResponse(User user) {
-        if (user == null) {
-            // 처리 필요
-        }
         this.id = user.getId();
         this.nickname = user.getNickname();
     }

--- a/back-end/src/main/java/com/j2kb5th/chippo/global/exception/ErrorMessage.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/global/exception/ErrorMessage.java
@@ -1,0 +1,45 @@
+package com.j2kb5th.chippo.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorMessage {
+
+    /**
+     * AD### : Admin Error
+     */
+    AD001("에러 메시지 내용을 작성"),
+
+
+    /**
+     * CO### : Comment Error
+     */
+
+    /**
+     * IN### : Interview Error
+     */
+    IN001("interview"),
+
+    /**
+     * PR### : PreAnswer Error
+     */
+
+    /**
+     * TA### : Tag Error
+     */
+
+    /**
+     * TH### : Thumb Error
+     */
+
+    /**
+     * US### : User Error
+     */
+    ;
+
+    private final String message;
+
+    ErrorMessage(String message) {
+        this.message = message;
+    }
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/global/exception/ErrorMessage.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/global/exception/ErrorMessage.java
@@ -10,6 +10,7 @@ public enum ErrorMessage {
      */
     GL001("유저 정보를 찾을 수 없습니다."),
     GL002("인터뷰 정보를 찾을 수 없습니다."),
+    GL003("로그인이 필요합니다."),
 
 
     /**
@@ -27,6 +28,7 @@ public enum ErrorMessage {
      */
     IN001("interview"),
 
+
     /**
      * PR### : PreAnswer Error
      */
@@ -34,6 +36,8 @@ public enum ErrorMessage {
     /**
      * TA### : Tag Error
      */
+    TA001("기술스택 태그를 1개 이상 작성해야 합니다."),
+    TA002("기술스택 태그는 3개까지 작성 가능합니다."),
 
     /**
      * TH### : Thumb Error

--- a/back-end/src/main/java/com/j2kb5th/chippo/global/exception/ErrorMessage.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/global/exception/ErrorMessage.java
@@ -26,7 +26,7 @@ public enum ErrorMessage {
     /**
      * IN### : Interview Error
      */
-    IN001("interview"),
+    IN001("인터뷰 정보를 찾을 수 없습니다."),
 
 
     /**

--- a/back-end/src/main/java/com/j2kb5th/chippo/global/exception/ErrorMessage.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/global/exception/ErrorMessage.java
@@ -6,6 +6,12 @@ import lombok.Getter;
 public enum ErrorMessage {
 
     /**
+     * GL### : Global Error
+     */
+    GL001("유저 정보를 찾을 수 없습니다."),
+
+
+    /**
      * AD### : Admin Error
      */
     AD001("에러 메시지 내용을 작성"),

--- a/back-end/src/main/java/com/j2kb5th/chippo/global/exception/ErrorMessage.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/global/exception/ErrorMessage.java
@@ -9,6 +9,7 @@ public enum ErrorMessage {
      * GL### : Global Error
      */
     GL001("유저 정보를 찾을 수 없습니다."),
+    GL002("인터뷰 정보를 찾을 수 없습니다."),
 
 
     /**
@@ -41,7 +42,7 @@ public enum ErrorMessage {
     /**
      * US### : User Error
      */
-    ;
+
 
     private final String message;
 

--- a/back-end/src/main/java/com/j2kb5th/chippo/global/exception/ErrorMessage.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/global/exception/ErrorMessage.java
@@ -43,7 +43,7 @@ public enum ErrorMessage {
      * US### : User Error
      */
 
-
+    ;
     private final String message;
 
     ErrorMessage(String message) {

--- a/back-end/src/main/java/com/j2kb5th/chippo/global/exception/ErrorResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/global/exception/ErrorResponse.java
@@ -1,0 +1,10 @@
+package com.j2kb5th.chippo.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ErrorResponse {
+    private final String message;
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/global/exception/GlobalException.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/global/exception/GlobalException.java
@@ -1,0 +1,17 @@
+package com.j2kb5th.chippo.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import java.util.function.Supplier;
+
+@Getter
+public class GlobalException extends RuntimeException {
+    private final HttpStatus status;
+    private final String message;
+
+    public GlobalException(HttpStatus status, ErrorMessage error) {
+        this.status = status;
+        this.message = error.getMessage();
+    }
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/global/exception/GlobalExceptionHandler.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.j2kb5th.chippo.global.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(GlobalException.class)
+    public ResponseEntity<ErrorResponse> handleServiceException(GlobalException exception) {
+        return ResponseEntity
+                .status(exception.getStatus())
+                .body(new ErrorResponse(exception.getMessage()));
+    }
+}

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/InterviewController.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/InterviewController.java
@@ -3,6 +3,8 @@ package com.j2kb5th.chippo.interview.controller;
 import com.j2kb5th.chippo.config.auth.LoginUser;
 import com.j2kb5th.chippo.config.auth.dto.SessionUser;
 import com.j2kb5th.chippo.global.controller.dto.UserResponse;
+import com.j2kb5th.chippo.global.exception.ErrorMessage;
+import com.j2kb5th.chippo.global.exception.GlobalException;
 import com.j2kb5th.chippo.interview.controller.dto.request.SaveInterviewRequest;
 import com.j2kb5th.chippo.interview.controller.dto.request.SaveInterviewTagDetailRequest;
 import com.j2kb5th.chippo.interview.controller.dto.request.UpdateInterviewRequest;
@@ -18,6 +20,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -60,7 +63,7 @@ public class InterviewController {
             @RequestParam(name = "tag_name") String tagName,
             @RequestParam(name = "tag_type") TagType tagType,
             @RequestParam(name = "size") Long size
-    ){
+    ) throws Exception {
         List<Interview> interviews = interviewService.findInterviewsByTag(tagName, tagType, size);
         return ResponseEntity.ok(new InterviewListResponse(interviews));
     }
@@ -68,32 +71,18 @@ public class InterviewController {
     @Operation(summary = "기술면접 저장", description = "요청한 정보를 기술면접 게시글로 등록합니다.")
     @PostMapping
     public ResponseEntity<InterviewDetailResponse> saveInterview(
+            @LoginUser SessionUser user,
             UriComponentsBuilder uriBuilder,
             @Valid @RequestBody SaveInterviewRequest interviewRequest
     ){
-        List<InterviewTagDetailResponse> testTags = new ArrayList<>();
-        List<SaveInterviewTagDetailRequest> tags = interviewRequest.getInterviewTags();
-        for (int i=0; i<interviewRequest.getInterviewTags().size(); i++){
-            testTags.add(new InterviewTagDetailResponse(1L, tags.get(i).getType(), tags.get(i).getName()));
+        if (user == null) {
+            throw new GlobalException(HttpStatus.UNAUTHORIZED, ErrorMessage.GL003);
         }
+        Interview interview = interviewService.saveInterview(interviewRequest, user.getUserId());
+        InterviewDetailResponse detailResponse = new InterviewDetailResponse(interview, null, false);
 
-        Long testInterviewId = 100L;
-        InterviewDetailResponse testResponse = new InterviewDetailResponse(
-                testInterviewId,
-                new UserResponse(101L, "면접본사람"),
-                interviewRequest.getQuestion(),
-                interviewRequest.getAnswer(),
-                interviewRequest.getExtraInfo(),
-                null,
-                new InterviewThumbResponse(true, 9L),
-                testTags,
-                null,
-                LocalDateTime.now()
-        );
-
-        URI uri = uriBuilder.path("/api/interviews/{interviewId}").buildAndExpand(testInterviewId).toUri();
-        return ResponseEntity.created(uri).body(testResponse);
-//        return ResponseEntity.ok(null);
+        URI uri = uriBuilder.path("/api/interviews/{interviewId}").buildAndExpand(interview.getId()).toUri();
+        return ResponseEntity.created(uri).body(detailResponse);
     }
 
 
@@ -103,34 +92,34 @@ public class InterviewController {
             @Parameter(description = "기술면접 ID") @PathVariable(name = "interviewId") Long interviewId,
             @Valid @RequestBody UpdateInterviewRequest interviewRequest
     ){
-        List<InterviewCommentResponse> testComments = new ArrayList<>();
-        testComments.add(new InterviewCommentResponse(1L, new UserResponse(123L, "카카오꿈나무"),
-                "헉 정말 좋은 답변이네요!", LocalDateTime.now()));
-        testComments.add(new InterviewCommentResponse(2L, new UserResponse(123L, "배민에서 탈주한 사람"),
-                "여기저기거기에서 본 면접 질문과 비슷하네요.", LocalDateTime.now()));
-
-        List<InterviewTagDetailResponse> testTags = new ArrayList<>();
-        List<UpdateInterviewTagDetailRequest> tags = interviewRequest.getInterviewTags();
-        for (int i=0; i<interviewRequest.getInterviewTags().size(); i++){
-            testTags.add(new InterviewTagDetailResponse(1L, tags.get(i).getType(), tags.get(i).getName()));
-        }
-
-        Long testInterviewId = 100L;
-
-        InterviewDetailResponse testResponse = new InterviewDetailResponse(
-                testInterviewId,
-                new UserResponse(101L, "면접본사람"),
-                interviewRequest.getQuestion(),
-                interviewRequest.getAnswer(),
-                interviewRequest.getExtraInfo(),
-                null,
-                new InterviewThumbResponse(false, 9L),
-                testTags,
-                testComments,
-                LocalDateTime.now()
-        );
-        return ResponseEntity.ok(testResponse);
-//        return ResponseEntity.ok(null);
+//        List<InterviewCommentResponse> testComments = new ArrayList<>();
+//        testComments.add(new InterviewCommentResponse(1L, new UserResponse(123L, "카카오꿈나무"),
+//                "헉 정말 좋은 답변이네요!", LocalDateTime.now()));
+//        testComments.add(new InterviewCommentResponse(2L, new UserResponse(123L, "배민에서 탈주한 사람"),
+//                "여기저기거기에서 본 면접 질문과 비슷하네요.", LocalDateTime.now()));
+//
+//        List<InterviewTagDetailResponse> testTags = new ArrayList<>();
+//        List<UpdateInterviewTagDetailRequest> tags = interviewRequest.getInterviewTags();
+//        for (int i=0; i<interviewRequest.getInterviewTags().size(); i++){
+//            testTags.add(new InterviewTagDetailResponse(1L, tags.get(i).getType(), tags.get(i).getName()));
+//        }
+//
+//        Long testInterviewId = 100L;
+//
+//        InterviewDetailResponse testResponse = new InterviewDetailResponse(
+//                testInterviewId,
+//                new UserResponse(101L, "면접본사람"),
+//                interviewRequest.getQuestion(),
+//                interviewRequest.getAnswer(),
+//                interviewRequest.getExtraInfo(),
+//                null,
+//                new InterviewThumbResponse(false, 9L),
+//                testTags,
+//                testComments,
+//                LocalDateTime.now()
+//        );
+//        return ResponseEntity.ok(testResponse);
+        return ResponseEntity.ok(null);
     }
 
     @Operation(summary = "기술면접 삭제", description = "id를 이용해 기술면접 게시글을 삭제합니다. (실제 삭제)")

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/InterviewController.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/InterviewController.java
@@ -93,6 +93,7 @@ public class InterviewController {
 
         URI uri = uriBuilder.path("/api/interviews/{interviewId}").buildAndExpand(testInterviewId).toUri();
         return ResponseEntity.created(uri).body(testResponse);
+//        return ResponseEntity.ok(null);
     }
 
 
@@ -129,6 +130,7 @@ public class InterviewController {
                 LocalDateTime.now()
         );
         return ResponseEntity.ok(testResponse);
+//        return ResponseEntity.ok(null);
     }
 
     @Operation(summary = "기술면접 삭제", description = "id를 이용해 기술면접 게시글을 삭제합니다. (실제 삭제)")

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/InterviewController.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/InterviewController.java
@@ -49,10 +49,13 @@ public class InterviewController {
             @LoginUser SessionUser user,
             @Parameter(description = "기술면접 ID") @PathVariable(name = "interviewId") Long interviewId
     ){
-        Long userId = (user == null) ? null : user.getUserId();
+        PreAnswer preAnswer = null;
+        boolean clicked = false;
+        if (user != null){
+            preAnswer = preAnswerService.findUserPreAnswer(interviewId, user.getUserId());
+            clicked = thumbService.checkThumb(user.getUserId(), interviewId);
+        }
         Interview interview = interviewService.findInterviewById(interviewId);
-        PreAnswer preAnswer = preAnswerService.findUserPreAnswer(interviewId, userId);
-        boolean clicked = (user == null)? false: thumbService.checkThumb(userId, interviewId);
         return ResponseEntity.ok(new InterviewDetailResponse(interview, preAnswer, clicked));
     }
 

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/InterviewController.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/InterviewController.java
@@ -3,7 +3,7 @@ package com.j2kb5th.chippo.interview.controller;
 import com.j2kb5th.chippo.config.auth.LoginUser;
 import com.j2kb5th.chippo.config.auth.dto.SessionUser;
 import com.j2kb5th.chippo.global.controller.dto.UserResponse;
-import co현m.j2kb5th.chippo.interview.controller.dto.request.SaveInterviewRequest;
+import com.j2kb5th.chippo.interview.controller.dto.request.SaveInterviewRequest;
 import com.j2kb5th.chippo.interview.controller.dto.request.SaveInterviewTagDetailRequest;
 import com.j2kb5th.chippo.interview.controller.dto.request.UpdateInterviewRequest;
 import com.j2kb5th.chippo.interview.controller.dto.request.UpdateInterviewTagDetailRequest;
@@ -28,6 +28,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 
 @Tag(name = "기술면접(Interview)", description = "기술면접 API")
@@ -45,12 +46,9 @@ public class InterviewController {
             @LoginUser SessionUser user,
             @Parameter(description = "기술면접 ID") @PathVariable(name = "interviewId") Long interviewId
     ){
-        if (user == null) {
-            //
-        }
         Interview interview = interviewService.findInterviewById(interviewId);
         PreAnswer preAnswer = preAnswerService.findPreAnswerByInterviewId(interviewId);
-        boolean clicked = thumbService.checkThumb(user.getUserId(), interviewId);
+        boolean clicked = (user == null)? false: thumbService.checkThumb(user.getUserId(), interviewId);
         return ResponseEntity.ok(new InterviewDetailResponse(interview, preAnswer, clicked));
     }
 

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewCommentResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewCommentResponse.java
@@ -4,13 +4,11 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.j2kb5th.chippo.comment.domain.Comment;
 import com.j2kb5th.chippo.global.controller.dto.UserResponse;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
 
 
 @Getter
-@RequiredArgsConstructor // dummy data용 임시 어노테이션 (구현 후 제거)
 public class InterviewCommentResponse {
 
     private final Long id;

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewCommentResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewCommentResponse.java
@@ -15,7 +15,7 @@ public class InterviewCommentResponse {
     private final UserResponse user;
     private final String content;
 
-    @JsonFormat(pattern = "yyyy-MM-dd`T`HH:mm:ss", timezone = "Asia/Seoul")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     private final LocalDateTime updatedAt;
 
     public InterviewCommentResponse(Comment comment) {

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewDetailResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewDetailResponse.java
@@ -24,7 +24,7 @@ public class InterviewDetailResponse {
     private final List<InterviewTagDetailResponse> interviewTags;
     private final List<InterviewCommentResponse> comments;
 
-    @JsonFormat(pattern = "yyyy-NN-dd`T`HH:mm:ss", timezone = "Asia/Seoul")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     private final LocalDateTime updatedAt;
 
     public InterviewDetailResponse(Interview interview, PreAnswer preAnswer, boolean thumbClicked) {

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewDetailResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewDetailResponse.java
@@ -33,7 +33,7 @@ public class InterviewDetailResponse {
         this.question = interview.getQuestion();
         this.answer = interview.getAnswer();
         this.extraInfo = interview.getExtraInfo();
-        this.preAnswer = new InterviewPreAnswerResponse(preAnswer);
+        this.preAnswer = (preAnswer == null)? null: new InterviewPreAnswerResponse(preAnswer);
         this.thumb = new InterviewThumbResponse(thumbClicked, interview.getThumbs().stream().count());
         this.interviewTags = interview.getInterviewTags().stream()
                 .map((interviewTag) -> new InterviewTagDetailResponse(interviewTag.getTag()))

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewDetailResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewDetailResponse.java
@@ -5,14 +5,12 @@ import com.j2kb5th.chippo.global.controller.dto.UserResponse;
 import com.j2kb5th.chippo.interview.domain.Interview;
 import com.j2kb5th.chippo.preanswer.domain.PreAnswer;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
-@RequiredArgsConstructor // 임시용
 public class InterviewDetailResponse {
 
     private final Long id;

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewListResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewListResponse.java
@@ -1,17 +1,16 @@
 package com.j2kb5th.chippo.interview.controller.dto.response;
 
+import com.j2kb5th.chippo.interview.domain.Interview;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
-@RequiredArgsConstructor // 구현 후 삭제
 public class InterviewListResponse {
     private final List<InterviewResponse> interviews;
 
-    // 구현 시 추가
-//    public InterviewsResponse(List<Interview> interviews) {
-//        this.interviews = interviews.stream().map(InterviewResponse::new).collect(Collectors.toList());
-//    }
+    public InterviewListResponse(List<Interview> interviews) {
+        this.interviews = interviews.stream().map(InterviewResponse::new).collect(Collectors.toList());
+    }
 }

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewPreAnswerResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewPreAnswerResponse.java
@@ -1,5 +1,6 @@
 package com.j2kb5th.chippo.interview.controller.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.j2kb5th.chippo.global.controller.dto.UserResponse;
 import com.j2kb5th.chippo.preanswer.domain.PreAnswer;
 import lombok.Getter;
@@ -11,6 +12,8 @@ public class InterviewPreAnswerResponse {
     private final Long id;
     private final String content;
     private final UserResponse user;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     private final LocalDateTime updatedAt;
 
     public InterviewPreAnswerResponse(PreAnswer preAnswer) {

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewPreAnswerResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewPreAnswerResponse.java
@@ -3,12 +3,10 @@ package com.j2kb5th.chippo.interview.controller.dto.response;
 import com.j2kb5th.chippo.global.controller.dto.UserResponse;
 import com.j2kb5th.chippo.preanswer.domain.PreAnswer;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
-@RequiredArgsConstructor // 임시 어노테이션
 public class InterviewPreAnswerResponse {
     private final Long id;
     private final String content;

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewResponse.java
@@ -19,7 +19,7 @@ public class InterviewResponse {
     private final List<InterviewTagDetailResponse> interviewTags;
     private final Long thumbCount;
 
-    @JsonFormat(pattern = "yyyy-NN-dd`T`HH:mm:ss", timezone = "Asia/Seoul")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     private final LocalDateTime updatedAt;
 
     public InterviewResponse(Interview interview) {

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewResponse.java
@@ -4,14 +4,12 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.j2kb5th.chippo.global.controller.dto.UserResponse;
 import com.j2kb5th.chippo.interview.domain.Interview;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Getter
-@RequiredArgsConstructor // 임시용
 public class InterviewResponse {
 
     private final Long id;

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewTagDetailResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewTagDetailResponse.java
@@ -1,14 +1,11 @@
 package com.j2kb5th.chippo.interview.controller.dto.response;
 
-import com.j2kb5th.chippo.tag.domain.InterviewTag;
 import com.j2kb5th.chippo.tag.domain.Tag;
 import com.j2kb5th.chippo.tag.domain.TagType;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 
 @Getter
-@RequiredArgsConstructor // 임시 어노테이션
 public class InterviewTagDetailResponse {
     private final Long id;
     private final TagType type;

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewTagDetailResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewTagDetailResponse.java
@@ -12,7 +12,6 @@ public class InterviewTagDetailResponse {
     private final String name;
 
     public InterviewTagDetailResponse(Tag tag){
-        // 예외처리 필요
         this.id = tag.getId();
         this.type = tag.getType();
         this.name = tag.getName();

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewThumbResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewThumbResponse.java
@@ -1,9 +1,11 @@
 package com.j2kb5th.chippo.interview.controller.dto.response;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import javax.validation.constraints.NotNull;
 
+@RequiredArgsConstructor
 @Getter
 public class InterviewThumbResponse {
 

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewThumbResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/controller/dto/response/InterviewThumbResponse.java
@@ -1,13 +1,9 @@
 package com.j2kb5th.chippo.interview.controller.dto.response;
 
-import com.j2kb5th.chippo.thumb.domain.Thumb;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import javax.validation.constraints.NotNull;
-import java.util.List;
 
-@RequiredArgsConstructor // 임시
 @Getter
 public class InterviewThumbResponse {
 

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/service/InterviewService.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/service/InterviewService.java
@@ -1,4 +1,11 @@
 package com.j2kb5th.chippo.interview.service;
 
+import com.j2kb5th.chippo.interview.domain.Interview;
+import com.j2kb5th.chippo.tag.domain.TagType;
+
+import java.util.List;
+
 public interface InterviewService {
+    Interview findInterviewById(Long interviewId);
+    List<Interview> findInterviewsByTag(String tagName, TagType tagType, Long size);
 }

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/service/InterviewService.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/service/InterviewService.java
@@ -1,5 +1,6 @@
 package com.j2kb5th.chippo.interview.service;
 
+import com.j2kb5th.chippo.interview.controller.dto.request.SaveInterviewRequest;
 import com.j2kb5th.chippo.interview.domain.Interview;
 import com.j2kb5th.chippo.tag.domain.TagType;
 
@@ -7,5 +8,7 @@ import java.util.List;
 
 public interface InterviewService {
     Interview findInterviewById(Long interviewId);
-    List<Interview> findInterviewsByTag(String tagName, TagType tagType, Long size);
+    List<Interview> findInterviewsByTag(String tagName, TagType tagType, Long size) throws Exception;
+
+    Interview saveInterview(SaveInterviewRequest interviewRequest, Long userId);
 }

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/service/InterviewServiceImpl.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/service/InterviewServiceImpl.java
@@ -8,11 +8,11 @@ import com.j2kb5th.chippo.interview.repository.InterviewRepository;
 import com.j2kb5th.chippo.tag.domain.InterviewTag;
 import com.j2kb5th.chippo.tag.domain.Tag;
 import com.j2kb5th.chippo.tag.domain.TagType;
-import com.j2kb5th.chippo.tag.repository.InterviewTagRepository;
 import com.j2kb5th.chippo.tag.repository.TagRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
 import java.util.List;
@@ -25,12 +25,14 @@ public class InterviewServiceImpl implements InterviewService {
     private final TagRepository tagRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public Interview findInterviewById(Long interviewId) {
         return interviewRepository.findById(interviewId)
                 .orElseThrow(() -> new GlobalException(HttpStatus.NOT_FOUND, ErrorMessage.IN001));
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<Interview> findInterviewsByTag(String tagName, TagType tagType, Long size) {
         // 처리 순서
         // 태그 정보(name, type) -> 태그 객체 찾기
@@ -46,13 +48,13 @@ public class InterviewServiceImpl implements InterviewService {
 
         // 인터뷰태그 객체(의 인터뷰 id) -> 인터뷰 객체 찾기
         List<Interview> interviews = interviewTags.stream()
-                .map(interviewTag -> interviewRepository.findById(interviewTag.getInterview().getId())
-                        .orElseThrow(() -> new GlobalException(HttpStatus.NOT_FOUND, ErrorMessage.GL002)))
+                .map(interviewTag -> findInterviewById(interviewTag.getInterview().getId()))
                 .collect(Collectors.toList());
         return interviews;
     }
 
     @Override
+    @Transactional
     public Interview saveInterview(SaveInterviewRequest interviewRequest, Long userId) {
         ///// 태그
         // 기술스택 미작성 시 에러

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/service/InterviewServiceImpl.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/service/InterviewServiceImpl.java
@@ -1,11 +1,36 @@
 package com.j2kb5th.chippo.interview.service;
 
+import com.j2kb5th.chippo.global.exception.ErrorMessage;
+import com.j2kb5th.chippo.global.exception.GlobalException;
+import com.j2kb5th.chippo.interview.domain.Interview;
 import com.j2kb5th.chippo.interview.repository.InterviewRepository;
+import com.j2kb5th.chippo.tag.domain.TagType;
+import com.j2kb5th.chippo.tag.repository.TagRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
 public class InterviewServiceImpl implements InterviewService {
     private final InterviewRepository interviewRepository;
+    private final TagRepository tagRepository;
+
+    @Override
+    public Interview findInterviewById(Long interviewId) {
+        return interviewRepository.findById(interviewId)
+                .orElseThrow(() -> new GlobalException(HttpStatus.NOT_FOUND, ErrorMessage.IN001));
+    }
+
+    @Override
+    public List<Interview> findInterviewsByTag(String tagName, TagType tagType, Long size) {
+        // 처리 순서
+        // 태그 정보(name, type) -> 태그 객체 찾기
+        // 태그 객체(태그 id) -> 인터뷰태그 객체 찾기
+        // 인터뷰태그 객체(의 인터뷰 id) -> 인터뷰 객체 찾기
+        // 이게 뭔데.... 어떻게 하는 건데...
+        return null;
+    }
 }

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/service/InterviewServiceImpl.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/service/InterviewServiceImpl.java
@@ -2,6 +2,7 @@ package com.j2kb5th.chippo.interview.service;
 
 import com.j2kb5th.chippo.global.exception.ErrorMessage;
 import com.j2kb5th.chippo.global.exception.GlobalException;
+import com.j2kb5th.chippo.interview.controller.dto.request.SaveInterviewRequest;
 import com.j2kb5th.chippo.interview.domain.Interview;
 import com.j2kb5th.chippo.interview.repository.InterviewRepository;
 import com.j2kb5th.chippo.tag.domain.InterviewTag;
@@ -13,18 +14,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @RequiredArgsConstructor
 @Service
 public class InterviewServiceImpl implements InterviewService {
     private final InterviewRepository interviewRepository;
     private final TagRepository tagRepository;
-    private final InterviewTagRepository interviewTagRepository;
 
     @Override
     public Interview findInterviewById(Long interviewId) {
@@ -38,19 +36,34 @@ public class InterviewServiceImpl implements InterviewService {
         // 태그 정보(name, type) -> 태그 객체 찾기
         List<Tag> tags = tagRepository.findByNameAndType(tagName, tagType);
 
+
         // 태그 객체(태그 id) -> 인터뷰태그 객체 찾기
         // 중복 방지를 위해 Set 타입 사용
-        Set<InterviewTag> interviewTags = tags.stream()
-                .map(tag -> interviewTagRepository.findByTagId(tag.getId()))
-                .flatMap(s -> s.stream())
-                .collect(Collectors.toSet());
+        List<InterviewTag> interviewTags = tags.stream()
+                .map(tag -> tag.getInterviewTags())
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
 
         // 인터뷰태그 객체(의 인터뷰 id) -> 인터뷰 객체 찾기
         List<Interview> interviews = interviewTags.stream()
                 .map(interviewTag -> interviewRepository.findById(interviewTag.getInterview().getId())
                         .orElseThrow(() -> new GlobalException(HttpStatus.NOT_FOUND, ErrorMessage.GL002)))
                 .collect(Collectors.toList());
-
         return interviews;
+    }
+
+    @Override
+    public Interview saveInterview(SaveInterviewRequest interviewRequest, Long userId) {
+        ///// 태그
+        // 기술스택 미작성 시 에러
+        Long techStackCount = interviewRequest.getInterviewTags().stream()
+                .filter(interviewTag -> interviewTag.getType().equals(TagType.TECHSTACK))
+                .count();
+        if (techStackCount == 0) {
+            throw new GlobalException(HttpStatus.BAD_REQUEST, ErrorMessage.TA001);
+        } else if (techStackCount > 3) {
+            throw new GlobalException(HttpStatus.BAD_REQUEST, ErrorMessage.TA002);
+        }
+        return null;
     }
 }

--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/service/InterviewServiceImpl.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/service/InterviewServiceImpl.java
@@ -4,19 +4,27 @@ import com.j2kb5th.chippo.global.exception.ErrorMessage;
 import com.j2kb5th.chippo.global.exception.GlobalException;
 import com.j2kb5th.chippo.interview.domain.Interview;
 import com.j2kb5th.chippo.interview.repository.InterviewRepository;
+import com.j2kb5th.chippo.tag.domain.InterviewTag;
+import com.j2kb5th.chippo.tag.domain.Tag;
 import com.j2kb5th.chippo.tag.domain.TagType;
+import com.j2kb5th.chippo.tag.repository.InterviewTagRepository;
 import com.j2kb5th.chippo.tag.repository.TagRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @RequiredArgsConstructor
 @Service
 public class InterviewServiceImpl implements InterviewService {
     private final InterviewRepository interviewRepository;
     private final TagRepository tagRepository;
+    private final InterviewTagRepository interviewTagRepository;
 
     @Override
     public Interview findInterviewById(Long interviewId) {
@@ -28,9 +36,21 @@ public class InterviewServiceImpl implements InterviewService {
     public List<Interview> findInterviewsByTag(String tagName, TagType tagType, Long size) {
         // 처리 순서
         // 태그 정보(name, type) -> 태그 객체 찾기
+        List<Tag> tags = tagRepository.findByNameAndType(tagName, tagType);
+
         // 태그 객체(태그 id) -> 인터뷰태그 객체 찾기
+        // 중복 방지를 위해 Set 타입 사용
+        Set<InterviewTag> interviewTags = tags.stream()
+                .map(tag -> interviewTagRepository.findByTagId(tag.getId()))
+                .flatMap(s -> s.stream())
+                .collect(Collectors.toSet());
+
         // 인터뷰태그 객체(의 인터뷰 id) -> 인터뷰 객체 찾기
-        // 이게 뭔데.... 어떻게 하는 건데...
-        return null;
+        List<Interview> interviews = interviewTags.stream()
+                .map(interviewTag -> interviewRepository.findById(interviewTag.getInterview().getId())
+                        .orElseThrow(() -> new GlobalException(HttpStatus.NOT_FOUND, ErrorMessage.GL002)))
+                .collect(Collectors.toList());
+
+        return interviews;
     }
 }

--- a/back-end/src/main/java/com/j2kb5th/chippo/preanswer/controller/dto/response/PreAnswerResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/preanswer/controller/dto/response/PreAnswerResponse.java
@@ -1,5 +1,6 @@
 package com.j2kb5th.chippo.preanswer.controller.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.j2kb5th.chippo.global.controller.dto.UserResponse;
 import com.j2kb5th.chippo.preanswer.domain.PreAnswer;
 import lombok.Getter;
@@ -13,6 +14,8 @@ public class PreAnswerResponse {
     private final Long id;
     private final String content;
     private final UserResponse user;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     private final LocalDateTime updatedAt; // 논의 필요
 
     public PreAnswerResponse(PreAnswer preAnswer) {

--- a/back-end/src/main/java/com/j2kb5th/chippo/preanswer/repository/PreAnswerRepository.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/preanswer/repository/PreAnswerRepository.java
@@ -3,5 +3,7 @@ package com.j2kb5th.chippo.preanswer.repository;
 import com.j2kb5th.chippo.preanswer.domain.PreAnswer;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PreAnswerRepository extends JpaRepository<PreAnswer, Long> {
 }

--- a/back-end/src/main/java/com/j2kb5th/chippo/preanswer/service/PreAnswerService.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/preanswer/service/PreAnswerService.java
@@ -1,4 +1,7 @@
 package com.j2kb5th.chippo.preanswer.service;
 
+import com.j2kb5th.chippo.preanswer.domain.PreAnswer;
+
 public interface PreAnswerService {
+    PreAnswer findPreAnswerByInterviewId(Long interviewId);
 }

--- a/back-end/src/main/java/com/j2kb5th/chippo/preanswer/service/PreAnswerServiceImpl.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/preanswer/service/PreAnswerServiceImpl.java
@@ -1,5 +1,6 @@
 package com.j2kb5th.chippo.preanswer.service;
 
+import com.j2kb5th.chippo.preanswer.domain.PreAnswer;
 import com.j2kb5th.chippo.preanswer.repository.PreAnswerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -9,4 +10,9 @@ import org.springframework.stereotype.Service;
 public class PreAnswerServiceImpl implements PreAnswerService {
 
     private final PreAnswerRepository preAnswerRepository;
+
+    @Override
+    public PreAnswer findPreAnswerByInterviewId(Long interviewId) {
+        return null;
+    }
 }

--- a/back-end/src/main/java/com/j2kb5th/chippo/tag/repository/InterviewTagRepository.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/tag/repository/InterviewTagRepository.java
@@ -3,5 +3,8 @@ package com.j2kb5th.chippo.tag.repository;
 import com.j2kb5th.chippo.tag.domain.InterviewTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface InterviewTagRepository extends JpaRepository<InterviewTag, Long> {
+    List<InterviewTag> findByTagId(Long id);
 }

--- a/back-end/src/main/java/com/j2kb5th/chippo/tag/repository/TagRepository.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/tag/repository/TagRepository.java
@@ -1,7 +1,11 @@
 package com.j2kb5th.chippo.tag.repository;
 
 import com.j2kb5th.chippo.tag.domain.Tag;
+import com.j2kb5th.chippo.tag.domain.TagType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TagRepository extends JpaRepository<Tag, Long> {
+    List<Tag> findByNameAndTag(String tagName, TagType tagType);
 }

--- a/back-end/src/main/java/com/j2kb5th/chippo/tag/repository/TagRepository.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/tag/repository/TagRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
-    List<Tag> findByNameAndTag(String tagName, TagType tagType);
+    List<Tag> findByNameAndType(String tagName, TagType tagType);
 }

--- a/back-end/src/main/java/com/j2kb5th/chippo/thumb/controller/dto/response/ThumbResponse.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/thumb/controller/dto/response/ThumbResponse.java
@@ -13,7 +13,7 @@ public class ThumbResponse {
 
     private final Long id;
 
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     private final LocalDateTime createdAt;
 
     public ThumbResponse(Thumb thumb) {

--- a/back-end/src/main/java/com/j2kb5th/chippo/thumb/service/ThumbService.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/thumb/service/ThumbService.java
@@ -1,4 +1,5 @@
 package com.j2kb5th.chippo.thumb.service;
 
 public interface ThumbService {
+    boolean checkThumb(Long userId, Long interviewId);
 }

--- a/back-end/src/main/java/com/j2kb5th/chippo/thumb/service/ThumbServiceImpl.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/thumb/service/ThumbServiceImpl.java
@@ -8,4 +8,9 @@ import org.springframework.stereotype.Service;
 @Service
 public class ThumbServiceImpl implements ThumbService {
     private final ThumbRepository thumbRepository;
+
+    @Override
+    public boolean checkThumb(Long userId, Long interviewId) {
+        return false;
+    }
 }


### PR DESCRIPTION
## 내용
- 기술면접 단건 / 목록 조회 기능 구현
- 사전답안, 따봉 등의 조회는 메소드만 만들어놓았습니다.

## 참고
- 글로벌 예외처리 추가 -> 코드 참고하셔서 앞으로 서비스 레이어에서 사용하시면 됩니다!

## 이슈
조회: solve #50 
등록/수정/삭제: #51 