### PR TITLE
<#88> fix: 기술면접(interview) 메서드 복귀

### DIFF
--- a/back-end/src/main/java/com/j2kb5th/chippo/interview/domain/Interview.java
+++ b/back-end/src/main/java/com/j2kb5th/chippo/interview/domain/Interview.java
@@ -61,4 +61,24 @@ public class Interview extends BaseTimeEntity {
     public void addComment(Comment comment) {
         this.comments.add(comment);
     }
+
+    public void addInterviewTag(InterviewTag interviewTag) {
+        this.interviewTags.add(interviewTag);
+    }
+
+    public void removeInterviewTag(InterviewTag interviewTag) {
+        this.interviewTags.removeIf(it -> it.getId() == interviewTag.getId());
+    }
+
+    public void updateQuestion(String question) {
+        this.question = question;
+    }
+
+    public void updateAnswer(String answer) {
+        this.answer = answer;
+    }
+
+    public void updateExtraInfo(String extraInfo) {
+        this.extraInfo = extraInfo;
+    }
 }


### PR DESCRIPTION
## 내용
- 브랜치 병합 시 날아간 인터뷰 메서드들을 다시 추가합니다.
- 상세 내용
    - Interview 엔티티 내 addInterviewTag, removeInterviewTag, updateQuestion, updateAnswer, updateExtraInfo 메서드 추가

## 참고
- resolve #88 
